### PR TITLE
Add mode diffusion analysis & handle NaN outliers

### DIFF
--- a/actinPropPerTimeInterval.m
+++ b/actinPropPerTimeInterval.m
@@ -1,0 +1,367 @@
+function [actinPropPerTimeInt] = actinPropPerTimeInterval(qfsmPackPaths, actinConditions)
+%ACTINPROPPERTIMEINTERVAL : reads results from QFSM Package and calculates spatiotemporal properties of speckles per FSM frame
+%
+%SYNOPSIS: [actinPropPerTimeInt] = actinPropPerTimeInterval(qfsmPackPaths, actinConditions)
+%
+%INPUT:   qfsmPackPaths : (n x 1 cell) paths leading to QFSM Package results.
+%
+%       actinConditions : (structure) parameters for processing speckles;
+%                         contains the following fields:
+%
+%                        .rad_density: (n x 1 vector of integer) search radius for
+%                                     neighboring speckles for individual speckle
+%                                     density calculation. Recommended value: 7
+%
+%                        .maskLoc    : (n x 1 vector of integer) flag indicating
+%                                     location of cell ROI mask.
+%                            = 0 : there exists a folder with external
+%                                  masks within path provided in
+%                                  qfsmPackPaths (make sure folder name
+%                                  follows a name in extlroi variable.)
+%                            = 1 : externalROI or segmentation package's
+%                                  mask (for MANUAL user hand-drawn mask).
+%                                  There exists a folder with refined
+%                                  masks within the SegmentationPackage (or
+%                                  WindowingPackage) folder provided in 
+%                                  qfsmPackPaths.
+%                            = 2 : there exists a folder with refined
+%                                  masks within the QFSMPackage folder
+%                                  provided in qfsmPackPaths (AUTOMATED
+%                                  detection by QFSM package).
+%                            If [] or other values, code will crash.
+%
+%                        .pos_std    : (n x 1 vector of integer) flag for
+%                                     adding noise into speckle position data.
+%                                    = 1 : gaussian noise will be added to speckle
+%                                          positions. Noise follows Normal ~ (0,(15nm/90).^2)
+%                                    = 0 or any value not 1: No noise added.
+%
+%                        .minLft     : (n x 1 vector of integer) minimum speckle
+%                                  lifetime to use in analysis. Recommended
+%                                  value: 2 (to remove "ghost" speckles)
+%
+%OUTPUT: actinPropPerTimeInt: (n x 1 cell array of structures) FSM arm
+%                             analysis results of SMI-FSM analysis for n
+%                             movies; each structure contain speckle
+%                             properties for m FSM intervals, containing
+%                             the following fields:
+%
+%               .speckleList      : List of speckles that exist in the frame
+%
+%               .kinScore         : The kinetic score from the QFSM package
+%
+%               .kinScorePos      : The positions at which we have kinetic scores
+%                                   (units: pixels)
+%
+%               .speckleInitPos   : The speckle position for a particular FSM
+%                                   frame (prior frame of the interval) (units: pixels)
+%
+%               .speckleMidPos    : The speckle midpoint position between 2
+%                                   FSM frames of an FSM interval (units: pixels)
+%
+%               .speckleVelocity  : The speckle velocity (displacement) from
+%                                   a frame to the next frame (units: pixels/frame)
+%                                   = NaN if that speckle does not exist in
+%                                   the next frame.
+%
+%               .speckleSpeed     : The speckle speed (displacement magnitude)
+%                                   from one FSM frame to the next (units: pixels/frame)
+%
+%               .speckleMvmtCohere: The average comovement between a speckle
+%                                   and its neighboring speckles.
+%
+%               .maskDensity      : The number of speckles within a cell ROI
+%                                   mask divided by the number of pixels
+%                                   comprising the mask.
+%
+%               .indxMask         : Indices of the mask obtained from QFSM package
+%
+%               .ILmax            : intensity of a specific speckle, as
+%                                   reported from QFSM package.
+%
+%               .IBkg             : background intensity around a specific
+%                                   speckle, as reported from QFSM package.
+%
+%               .ILmaxNeighb      : average intensity of speckles in the
+%                                   neighborhood of a specific speckle.
+%
+%               .IBkgNeighb       : average background intensity of speckles
+%                                   in the neighborhood of a specific speckle.
+%
+% Deryl Tschoerner, February 2018
+% modified: Tra H Ngo, February 2019 (remove ghost speckle)
+% modified: Tra H Ngo, Aug. 2019 (add speckleLifetime properties)
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% definitions
+numMovs = length(qfsmPackPaths);
+fs = filesep;
+maps = cell(numMovs,1);
+actinPropPerTimeInt = cell(numMovs,1);
+fsmFrames = nan(numMovs,1);
+
+for i = 1 : numMovs
+    %% Get number of FSM frames
+    %field names for the variables found in the kineticAnalysis folder
+    maps{i,1} = dir(strcat([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'kineticAnalysis' fs '*.mat']));
+    if isempty(maps{i,1})
+        warning('Structure of QFSM kinetic analysis folder is not as expected.')
+        warning('Automatic debugging. Contact developers for details.')
+        kineticAnalysisFolder = dir([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'kineticAnalysis']);
+        indxPotentialResFolder = find([kineticAnalysisFolder(3:end).isdir]);
+        if length(indxPotentialResFolder) == 1
+            subfolderName = kineticAnalysisFolder(indxPotentialResFolder+2).name;
+            kinAnalysisFolder_updated = [kineticAnalysisFolder(indxPotentialResFolder+2).folder fs subfolderName];
+            maps{i,1} = dir(strcat([kinAnalysisFolder_updated fs '*.mat']));
+        else
+            error('Cannot find results of QFSM kinetic analysis.')
+        end
+    end
+    
+    fsmFrames(i,1) = length(maps{i,1});
+    
+    %% If path does not exist, skip to the next movie
+    if isempty(qfsmPackPaths{i,1})
+        continue
+    end
+    
+    %% Load & analyze speckle tracks (MPM)
+    try
+        load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckleTracks' fs '_tracks.mat'], 'MPM');
+    catch % 20230427: with Glass4h dataset, output of QFSM is no longer named "_tracks.mat" but was named "m-01-01.tif Channel 1_tracks.mat"
+        tmpFsmNames = dir([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckleTracks']);
+        tmpFsmResName = tmpFsmNames(3).name;
+        load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckleTracks' fs tmpFsmResName], 'MPM');
+    end
+    % remove ghost speckles and calculate speckle lifetime properties
+    [MPM,lifetimeMPM] = retainMPMminLifetime(MPM, actinConditions.minLft(i));
+    
+    %KJ 20210707: indicate complete vs. incomplete speckle lifetime
+    flagCompleteLft = ones(size(lifetimeMPM));
+    indxFirstFrame = find(lifetimeMPM(:,1) > 0);
+    for iRow = indxFirstFrame'
+        flagCompleteLft(iRow,1:2*lifetimeMPM(iRow,1)) = 0;
+    end
+    indxLastFrame = find(lifetimeMPM(:,end) > 0);
+    for iRow = indxLastFrame'
+        flagCompleteLft(iRow,end-2*lifetimeMPM(iRow,end)+1:end) = 0;
+    end
+    
+    MPM(MPM == 0) = NaN; MPM(:,end + 1 : end + 2) = NaN; %TN2019: replace zeros with NaN
+    
+    if actinConditions.pos_std(i) == 1, noise = normrnd(0,15/90,size(MPM)); MPM = MPM + noise; end
+    
+    %store field names for readout of values from the structure fields found
+    %in 'maps' variable
+    temp = repmat(struct('polyMap',[],'kinScore',[],'depolyMap',[], ...
+        'kinMap2C',[]),fsmFrames(i,1),1);
+    
+    %field names for vector of structures holding speckle properties
+    actinPropPerTimeInt{i,1} = repmat(struct('kinScorePos',[],'kinScore',[], ...
+        'speckleList',[],'speckleInitPos',[],'speckleMidPos',[], ...
+        'speckleVelocity',[],'speckleSpeed',[],'speckleDensity',[] , ...
+        'speckleMvmtCohere',[],'speckleLifetime',[],'flagCompleteLft',[], ...
+        'ILmax', [], 'IBkg', [], 'ILmaxNeighb', [], 'IBkgNeighb', []),...
+        fsmFrames(i,1),1);
+    
+    masks = getActinMask(qfsmPackPaths(i,1), actinConditions.maskLoc(i));
+    %only retain movieInfo features that exist within mask
+    
+    %% Get speckle props   
+    for j = 1 : fsmFrames(i,1)
+        
+        %% get ILmax & IBkg - TN 20210524
+        % Load speckle cands structure for intensity of speckle and background
+        try
+            if fsmFrames(i,1) < 10
+                load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckles' fs 'cands_' num2str(j,'%01.f') '.mat'], 'cands');
+            elseif fsmFrames(i,1) < 100
+                load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckles' fs 'cands_' num2str(j,'%02.f') '.mat'], 'cands');
+            elseif fsmFrames(i,1) < 1000
+                % if actin movie is >100 frames then the first cands will be named ..001.mat and so on.
+                load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckles' fs 'cands_' num2str(j,'%03.f') '.mat'], 'cands');
+            else
+                error('Loading cands is not accounting for >999 fsm frames');
+            end
+        catch
+            warning('Folder of QFSM results for speckle candidates is not structured as expected.')
+            warning('Automatic debugging. Contact developers for details.')
+            if fsmFrames(i,1) < 10
+                load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckles' fs subfolderName fs 'cands_' num2str(j,'%01.f') '.mat'], 'cands');
+            elseif fsmFrames(i,1) < 100
+                load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckles' fs subfolderName fs 'cands_' num2str(j,'%02.f') '.mat'], 'cands');
+            elseif fsmFrames(i,1) < 1000
+                % if actin movie is >100 frames then the first cands will be named ..001.mat and so on.
+                load([qfsmPackPaths{i,1} fs 'QFSMPackage' fs 'speckles' fs subfolderName fs 'cands_' num2str(j,'%03.f') '.mat'], 'cands');
+            else
+                error('Loading cands is not accounting for >999 fsm frames');
+            end
+        end
+        
+        lmaxAll = vertcat(cands.Lmax);
+        
+        %% get .kinScorePos, .kinScore, .specklePosInit, .speckleVelocity, and
+        %% .speckleSpeed
+        
+        %assigning speckle list, initial positions, velocities, and speeds
+        actinPropPerTimeInt{i,1}(j,1).speckleList = find(~isnan(MPM(:,2*j)));
+        
+        %assigning positions of speckles with added noise (as (y,x) in
+        %MPM's coordinate)
+        actinPropPerTimeInt{i,1}(j,1).speckleInitPos = ...
+            [MPM(actinPropPerTimeInt{i,1}(j,1).speckleList,2*j), ...
+            MPM(actinPropPerTimeInt{i,1}(j,1).speckleList,2*j - 1)];
+        
+        switch actinConditions.maskLoc(i) % ~= 0
+            case {1,2} %extract (y,x) coordinates for all pixels within refined mask
+                [actinPropPerTimeInt{i,1}(j).indxMask(:,2), ...
+                    actinPropPerTimeInt{i,1}(j).indxMask(:,1)] = ...
+                    find(imread([masks{1}(j+2).folder fs masks{1}(j + 2).name]));
+            case 3
+                [actinPropPerTimeInt{i,1}(j).indxMask(:,2), ...
+                    actinPropPerTimeInt{i,1}(j).indxMask(:,1)] = ...
+                    find(imread([qfsmPackPaths{i,1} fs 'SegmentationPackage' fs 'refined_masks' ...
+                    fs 'refined_masks_for_channel_1' fs masks{1}(j + 2).name]));
+            otherwise
+                error('Unexpected actinConditions.maskLoc')
+        end
+        %indices of positions
+        pos = [actinPropPerTimeInt{i,1}(j).speckleInitPos(:,2) ...
+            actinPropPerTimeInt{i,1}(j).speckleInitPos(:,1)];
+        
+        actinPropPerTimeInt{i,1}(j).speckleMaskDensity = ...
+            sum(ismember(round(pos),[actinPropPerTimeInt{i,1}(j).indxMask(:,2), ...
+            actinPropPerTimeInt{i,1}(j).indxMask(:,1)],'rows')) / ...
+            length(actinPropPerTimeInt{i,1}(j).indxMask(:,1));
+        
+        %vector of directories
+        temp(j) = load([maps{i}(j).folder fs maps{i}(j).name]);
+        
+        %assigning kinetic scores and their positions
+        actinPropPerTimeInt{i,1}(j,1).kinScore = temp(j).kinScore(:,4);
+        actinPropPerTimeInt{i,1}(j,1).kinScorePos = ...
+            [temp(j).kinScore(:,3), temp(j).kinScore(:,2)];
+        
+        
+        %assigning intensity of speckle and background
+        ILmaxMat = nan(size(actinPropPerTimeInt{i,1}(j,1).speckleList,1),1);
+        IBkgMat = nan(size(actinPropPerTimeInt{i,1}(j,1).speckleList,1),1);
+        
+        for iSpkl = 1:size(actinPropPerTimeInt{i,1}(j,1).speckleList,1) % loop through each speckle detected in each FSM frame
+            
+            xPos = actinPropPerTimeInt{i,1}(j,1).speckleInitPos(iSpkl,2);
+            yPos = actinPropPerTimeInt{i,1}(j,1).speckleInitPos(iSpkl,1);
+            indSpklCurr = find(lmaxAll(:,1) == xPos & lmaxAll(:,2) == yPos);
+            
+            % Check if speckle location from cands and MPM match (expect
+            % everything to be matched, in the case that ghost speckles are removed)
+            if isempty(indSpklCurr)
+                error('Unknown error: Cands & MPM not matched. Speckle is not ghost!')
+            end
+            
+            ILmax = cands(indSpklCurr).ILmax;
+            IBkg  = cands(indSpklCurr).IBkg;
+            
+            % Save ILmax & IBkg in output structure
+            ILmaxMat(iSpkl,1) = ILmax;
+            IBkgMat(iSpkl,1) = IBkg;
+            
+        end
+        actinPropPerTimeInt{i,1}(j,1).ILmax = ILmaxMat;
+        actinPropPerTimeInt{i,1}(j,1).IBkg = IBkgMat;
+        
+        
+        %calculate speckle velocities and speeds
+        actinPropPerTimeInt{i,1}(j,1).speckleVelocity = ...
+            [MPM(actinPropPerTimeInt{i,1}(j,1).speckleList,2*j + 2) - ...
+            actinPropPerTimeInt{i,1}(j,1).speckleInitPos(:,1), ...
+            MPM(actinPropPerTimeInt{i,1}(j,1).speckleList,2*j + 1) - ...
+            actinPropPerTimeInt{i,1}(j,1).speckleInitPos(:,2)];
+        
+        actinPropPerTimeInt{i,1}(j,1).speckleSpeed = ...
+            sqrt(sum(actinPropPerTimeInt{i,1}(j,1).speckleVelocity .^ 2,2));
+        
+        %assigning speckle lifetime - TN20190828
+        actinPropPerTimeInt{i,1}(j,1).speckleLifetime = ...
+            lifetimeMPM(actinPropPerTimeInt{i,1}(j,1).speckleList,2*j);
+        
+        %assigning speckle lifetime flag - KJ20210707
+        actinPropPerTimeInt{i,1}(j,1).flagCompleteLft = ...
+            flagCompleteLft(actinPropPerTimeInt{i,1}(j,1).speckleList,2*j);
+        
+        %assigning speckle midpoint positions
+        actinPropPerTimeInt{i,1}(j,1).speckleMidPos = ...
+            actinPropPerTimeInt{i,1}(j,1).speckleInitPos + ...
+            (actinPropPerTimeInt{i,1}(j,1).speckleVelocity / 2);
+        
+        %distances of all speckles between each other for a given frame of speckles
+        distMats = createDistanceMatrix(actinPropPerTimeInt{i}(j).speckleInitPos, ...
+            actinPropPerTimeInt{i}(j).speckleInitPos);
+        
+        neighbhArea = (pi*(actinConditions.rad_density(i))^2);
+        for iCol = 1 : size(distMats,2)
+            matchindx = find(distMats(:,iCol) <= actinConditions.rad_density(i));
+            
+            actinPropPerTimeInt{i}(j).speckleDensity(iCol,1) = ...
+                length(matchindx) / neighbhArea;
+            
+            matchedVect = actinPropPerTimeInt{i,1}(j,1).speckleVelocity(matchindx,:);
+            matchedSpeed = actinPropPerTimeInt{i,1}(j,1).speckleSpeed(matchindx,:);
+            
+            %TN 20210808: add ILmaxNeighb & IBkgNeighb (to mirror
+            %ilmaxCorrected and ibkgCorrected when
+            %    If no matched neighbor, ilmaxNeighb = ilmax;
+            %    If there is a matched neighbor, ilmaxNeighb = (average ilmax)
+            matchedILmax = actinPropPerTimeInt{i,1}(j,1).ILmax(matchindx,:);
+            actinPropPerTimeInt{i}(j).ILmaxNeighb(iCol,1) = ...
+                mean(matchedILmax);
+            
+            matchedIBkg = actinPropPerTimeInt{i,1}(j,1).IBkg(matchindx,:);
+            actinPropPerTimeInt{i}(j).IBkgNeighb(iCol,1) = ...
+                mean(matchedIBkg);
+            
+            
+            %KJ 20210712: if only one speckle neighbor exists, or only one
+            %speckle neighbor has a velocity > 0, movement coherence is not
+            %relevant
+            if size(matchindx,1) == 1 || length(find(matchedSpeed > 0)) <= 1
+                actinPropPerTimeInt{i}(j).speckleMvmtCohere(iCol,1) = NaN;
+            else
+                
+                % To calculate speckleMvmtCohere, take the resultant vector
+                % magnitude, divide that by the average of speed of each
+                % vector that was added - TN 20190913; sum-over-sum
+                % strategy - TN 20191121
+                
+                resultantVect = sum(matchedVect);
+                
+                actinPropPerTimeInt{i}(j).speckleMvmtCohere(iCol,1) = ...
+                    sqrt(sum(resultantVect.^2)) / sum(matchedSpeed);
+                
+            end
+        end
+        
+    end %(for j = 1 : fsmFrames(i,1))
+    
+end %(for i = 1 : numMovs)
+
+end
+%% ~~~ the end ~~~

--- a/cleanActinPropPerTimeInt.m
+++ b/cleanActinPropPerTimeInt.m
@@ -1,0 +1,94 @@
+function [actinPropPerTimeIntClnSpeed,actinPropPerTimeIntClnLft,...
+    actinPropPerTimeIntClnSpeedLft] = cleanActinPropPerTimeInt(...
+    actinPropPerTimeInt,speedThresh)
+%CLEANACTINPROPPERTIMEINT replaces small speckle speeds and incomplete speckle lifetimes with 0 and NaN, respectively
+%
+%SYNOPSIS [actinPropPerTimeIntClnSpeed,actinPropPerTimeIntClnLft,...
+%     actinPropPerTimeIntClnSpeedLft] = cleanActinPropPerTimeInt(...
+%     actinPropPerTimeInt,speedThresh)
+%
+%INPUT  actinPropPerTimeInt: Cell array containing structures with various
+%                            fields containing actin speckle properties, as
+%                            output by actinPropPerTimeInterval.
+%       speedThresh        : Threshold below which speeds are replaced with
+%                            NaN (because they are difficult to tell apart
+%                            from apparent movement due to noise).
+%                            Example: speedThresh = 1.5;
+%
+%OUTPUT actinPropPerTimeIntClnSpeed: Same as input actinPropPerTimeInt, but
+%                            with speeds below threshold replaced by 0.
+%       actinPropPerTimeIntClnLft: Same as input actinPropPerTimeInt, but
+%                            with incomplete lifetimes replaced by NaN.
+%       actinPropPerTimeIntClnSpeedLft: Same as input actinPropPerTimeInt, but
+%                            with speeds below threshold replaced by 0 and
+%                            incomplete lifetimes replaced by NaN.
+%
+%Khuloud Jaqaman, July 2021
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%initialize output
+[actinPropPerTimeIntClnSpeed,actinPropPerTimeIntClnLft,...
+    actinPropPerTimeIntClnSpeedLft] = deal(actinPropPerTimeInt);
+
+%loop over movies
+numMovies = length(actinPropPerTimeInt);
+for iMovie = 1 : numMovies
+    
+    %get current movie info from input cell array
+    actinPropCurr = actinPropPerTimeInt{iMovie};
+    [actinPropClnSpeed,actinPropClnLft,actinPropClnSpeedLft] = deal(actinPropCurr);
+    
+    %loop over frames
+    numFrames = length(actinPropCurr);
+    for iFrame = 1 : numFrames
+        
+        %speckles with speed below threshold
+        speckleSpeed = actinPropCurr(iFrame).speckleSpeed;
+        indxBad = find(speckleSpeed < speedThresh);
+        
+        actinPropClnSpeed(iFrame).speckleSpeed(indxBad) = 0;
+        actinPropClnSpeed(iFrame).speckleVelocity(indxBad,:) = 0;
+        actinPropClnSpeed(iFrame).speckleMvmtCohere(indxBad) = NaN;
+       
+        actinPropClnSpeedLft(iFrame).speckleSpeed(indxBad) = 0;
+        actinPropClnSpeedLft(iFrame).speckleVelocity(indxBad,:) = 0;
+        actinPropClnSpeedLft(iFrame).speckleMvmtCohere(indxBad) = NaN;
+        
+        %speckles with incomplete lifetime
+        speckleLftFlag = actinPropCurr(iFrame).flagCompleteLft;
+        indxBad = find(speckleLftFlag==0);
+        
+        actinPropClnLft(iFrame).speckleLifetime(indxBad) = NaN;
+        
+        actinPropClnSpeedLft(iFrame).speckleLifetime(indxBad) = NaN;
+        
+    end %(for iFrame = 1 : numFrames)
+    
+    %store in output cell array
+    actinPropPerTimeIntClnSpeed{iMovie} = actinPropClnSpeed;
+    actinPropPerTimeIntClnLft{iMovie} = actinPropClnLft;
+    actinPropPerTimeIntClnSpeedLft{iMovie} = actinPropClnSpeedLft;
+    
+end %(for iMovie = 1 : numMovies)
+
+end
+
+%% ~~~ the end ~~~

--- a/multiCompareIndCellsMVRG.m
+++ b/multiCompareIndCellsMVRG.m
@@ -1,0 +1,189 @@
+function [inputBatchName, pSigIndCellArr, outlierIndxArr, sigRes, mvrgCoefStructArr] = multiCompareIndCellsMVRG(spekLabelBase, smLabelBase, displSpacing, varargin)
+%MULTICOMPAREINDCELLSMVRG: takes different testResult containing coefficients of multivariate regression of individual cells from different population (i.e. treatment conditions) and return significance comparisons.
+%
+%SYNOPSIS: [inputBatchName, pSigIndCellArr, outlierIndxArr, sigRes, mvrgCoefStructArr] = multiCompareIndCellsMVRG(spekLabelBase, smLabelBase, varargin)
+%
+%INPUT   :  spekLabelBase: (cell array) names of speckle properties of interest.
+%               i.e.: spekLabelBase = {'Speckle Speed', 'Speckle Local
+%               Density','Speckle Lifetime'};
+%
+%           smLabelBase  : (cell array) names of SM properties of interest.
+%               i.e.: smLabelBase = { 'SM Mean Amplitude','SM Diff Coef',
+%               'SM Local Density','smDiffusionRadius', 'SM Aggreg State'};
+%
+%           displSpacing : (2x1 matrix) allow user to input spacing parameters for final  
+%                          output notBoxPlot figure [spaceBtwEachBoxPlot, spaceBtwEachGroup]. 
+%
+%           vargarin     : Each input is a cell array of individual cells
+%                          testResult structure (which contain MVRG coefs).
+%                          If first cell array (3rd function input) is
+%                          logical value "true", then function expects only
+%                          2 treatment populations (2 testResults) and
+%                          perform ttest to compare, else, anovann is used.
+%                          Default comparison test is ANOVA. 
+%
+% Example for 3 and more (run ANOVA test):
+% [inputBatchName, pSigIndCellArr, outlierIndxArr, sigRes] = multiCompareIndCellsMVRG(spekLabelBase, smLabelBase, displSpacing, ...
+%     strInl_1.testResultSplitAbv, strInl_2.testResultSplitAbv, strInl_3.testResultSplitAbv, strInl_4.testResultSplitAbv);
+%
+% Example for 2 (run ttest2) -- 4th input MUST be true.
+%[inputBatchName, pSigIndCellArr, outlierIndxArr, sigRes] = multiCompareIndCellsMVRG(spekLabelBase, smLabelBase, displSpacing, ...
+%    true, strInl_1.testResultSplitAbv, strInl_2.testResultSplitAbv);
+%
+%OUTPUT  : function outputs folders containing different notBoxPlot figures
+%          of MVRG coefficients.
+%               For individual populations MVRG coefficients visualization:
+%                  folders named "indCellsMVRG#_(name of input variable)"
+%               For comparing between the different populations's MVRG
+%                  coefficients: 1 folder named "compareSigAnova" or
+%                  "compareSigTtest".
+%
+%          inputBatchName: array of cells, each containing string of
+%                          variable names of different treatment population
+%                          input. (i.e. "testResultsInd_C1_aboveTh")
+%                          Note that if an input is direct access (i.e.
+%                          a{1}), this string will be empty.
+%
+%          pSigIndCellArr: array of cells containing pSig of each population.
+%
+%          outlierIndxArr: array of cells containing outliers of each population.
+%
+%          sigRes        : either output of multiCompareAnovaIndCellsMVRG.m if AnovaN;
+%                          or structure contains 4 outputs of compareSigIndCellsMVRG.m if t-test.
+%
+%          mvrgCoefStructArr: (n x 1 cell array) each cell contains MVRG
+%                          coefficients from each batch of data that was input.
+%                          Each cell contain a structure with the following fields:
+%                                  .Immobile
+%                                  .Confined
+%                                  .Free
+%                                  .Directed
+%                                  .All
+%                          Which contains fields corresponding to the
+%                          dependpent variables from MVRG. Inside these
+%                          field is a matrix for MVRG coefficients, with
+%                          row = individual cell ROI (movie) and col =
+%                          indpendent variables from MVRG, whose names are
+%                          listed in the field "mvrgCoefStructArr.speckleLabel"
+%
+% Warning: Please always run this function in a new empty directory, because
+% this function create folders with set names and output figures into those folder!
+%
+% Tra Ngo, April 2021
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+
+%% Input:
+if nargin < 4
+    error('Function expects at least 4 inputs, with the first 2 inputs being labels of speckle and single-molecule properties.')
+end
+
+if isempty(displSpacing)
+    displSpacing = [0.4 5];
+elseif ~ismatrix(displSpacing) || size(displSpacing, 2) || 2 && size(displSpacing, 1) ~= 1 || ~isnumeric(displSpacing(1,1)) || ~isnumeric(displSpacing(1,2)) 
+    error(['Function expects the 3rd input to be matrix of spacing for display. \n' ...
+        'If user wants to use default display, use the following syntax: \n' ...
+        'multiCompareIndCellsMVRG(spekLabelBase, smLabelBase, [], dataset_1, dataset_2, ...)'], '') % note the '' is required to format \newline in error message
+end
+
+numBatch = nargin - 3; % number of testResult input
+%% Output:
+inputBatchName = cell(numBatch,1);
+for i = 1:numBatch
+    inputBatchName{i} = inputname(i+3);
+end
+
+%% Put variable inputs into cell array
+batchInputArr = varargin';
+
+%% Determine compare test: anovan? or ttest?
+if islogical(batchInputArr{1}) && batchInputArr{1}
+    if numBatch == 3
+        ttestFlag = true;
+        
+        % remove logic flag from batchInputArr, excessive name from
+        % inputBatchName, get the true number of treatment population being
+        % tested (i.e. numBatch):
+        
+        batchInputArr(1) = [];
+        inputBatchName(1) = [];
+        numBatch = numBatch-1;
+    else
+        error('Unexpected number of treatment population if ttest is requested. Expecting only 2 treatment populations.')
+    end
+elseif islogical(batchInputArr{1}) && ~batchInputArr{1}
+    error('Unexpected input: 3rd input cannot be logical value "false".')
+else
+    ttestFlag = false; % (default behavior)
+end
+
+%% Other outputs:
+pSigIndCellArr = cell(numBatch,1);
+outlierIndxArr = cell(numBatch,1);
+mvrgCoefStructArr = cell(numBatch,1);
+
+%% Check significance or individual population:
+
+for iBch = 1: numBatch
+    % batchInputArr = varargin{iBch};
+    folderName = ['indCellsMVRG' num2str(iBch) '_' inputBatchName{iBch}];
+    mkdir(folderName)
+    cd(folderName)
+    [pSigIndCellArr{iBch}, outlierIndxArr{iBch}, ~, mvrgCoefStructArr{iBch}] = ...
+        explainIndCellsMVRG(batchInputArr{iBch}, spekLabelBase, smLabelBase);
+    cd ..
+end
+
+
+%% Compare between populations:
+if numBatch ~= 1
+    switch ttestFlag
+        
+        case false % if ttestFlag is false, then perform compare using anovan
+            
+            mkdir('compareSigAnova')
+            cd('compareSigAnova')
+            [sigRes] = multiCompareAnovaIndCellsMVRG(batchInputArr,...
+                pSigIndCellArr, outlierIndxArr, spekLabelBase, smLabelBase, displSpacing);
+            cd ..
+            
+        case true % if ttestFlag is true, then perform compare using ttest
+            mkdir('compareSigTtest')
+            cd('compareSigTtest')
+            [pCompareTtestR,pCompareTtestL,outlierIndx1,outlierIndx2] = ...
+                compareSigIndCellsMVRG(batchInputArr{1},batchInputArr{2},...
+                pSigIndCellArr{1},pSigIndCellArr{2},...
+                spekLabelBase, smLabelBase);
+            cd ..
+            
+            sigRes.pCompareTtestR = pCompareTtestR;
+            sigRes.pCompareTtestL = pCompareTtestL;
+            sigRes.outlierIndx1 = outlierIndx1;
+            sigRes.outlierIndx2 = outlierIndx2;
+            
+    end % (switch ttestFlag)
+else
+    sigRes = 'No comparison. Only 1 population was input.';
+end % (if numBatch == 1) then don't do any compare
+
+%% If something comes out as different, implement multCompare to find what is different:
+
+end

--- a/plotBiphasicLines.m
+++ b/plotBiphasicLines.m
@@ -1,0 +1,139 @@
+function plotBiphasicLines(TRI, motionType, propVect, threshTab, cellNo, figStr, scalingFactor)
+%PLOTBIPHASICLINES: plot the fit lines for an individual cell from threshold and scatter data
+%
+%SYNOPSIS: plotBiphasicLines(TRI, motionType, propVect, threshTab, cellNo, figStr, scalingFactor)
+%
+%EXAMPLE: plotBiphasicLines(TRI, 2, [3 11], threshTab, 5, 'free')
+%
+%INPUT:    TRI        : Data of individual SM-speckle property to be
+%                       plotted, can be input in either of the two following formats:
+%
+%                       (n x 1 cell array) MVRG result for individual
+%                       cells. Must contain the field .aggMat for different
+%                       motion types (immobile, confined, free, directed).
+%                       Example: TRI = strInl.testResultAndSplit{1, 1};
+%                       See runSmactinAggMovExplain.m for details.
+%                                   ----------- OR -----------
+%                       (nx3 matrix) 1st col = x-Data, 2nd col = y-Data,
+%                       3rd col row 1 is threshold for this manual dataset.
+%                   
+%
+%           motionType: (interger) motion type to pull data from (0 =
+%                       immobile, 1 = confined, 2 = free, 3 = directed, 4 =
+%                       all).
+%
+%           propVect  : (1 x 2 vector) columns of .aggMat that are to be plotted
+%                     propVect(1) = x-axis data (e.g. col 3 = speckle density).
+%                     propVect(2) = y-axis data (e.g. col 11= sm diffusion
+%                                   coefficients, when there are 8 speckle properties).
+%                       See smactinAggMov.m for details
+%
+%           threshTab : (table) threshold from biphasic-scanning, must
+%                      include columns named:
+%                           .thresholds
+%                           .coefsOfMin
+%                       See scan4smSpeckleThreshold.m for details.
+%
+%           cellNo    : (interger) cell from TRI (nx1 cell array) that is
+%                       to be plotted. This is also the row of table
+%                       threshTab from which the thresholds and fit 
+%                       coefficients will be collected.
+%
+%           figStr    : (string) title of output figure
+%
+%           scalingFactor: (1x2 matrix) optional. Default [] = no scaling
+%                       scalingFactor(1) = scaling for x-axis
+%                       scalingFactor(2) = scaling for y-axis
+%
+%OUTPUT: figure plotting the fit lines for a particular cell on top of scatter data
+%        2-line: red; 1-line: black.
+%
+% Tra Ngo, Oct 2021
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Input
+if ~exist('scalingFactor','var')
+    scalingFactor = [];
+end
+
+%% Get x & y data and their range:
+if iscell(TRI)
+    if motionType <= 3
+        xDat = TRI{cellNo,1}{2, 1}.aggMat{1, motionType+1}(:,propVect(1));
+        yDat = TRI{cellNo,1}{2, 1}.aggMat{1, motionType+1}(:,propVect(2));
+    elseif motionType == 4 % get data for all motions
+        xDat = TRI{cellNo,1}{1, 1}.aggMat(:,propVect(1));
+        yDat = TRI{cellNo,1}{1, 1}.aggMat(:,propVect(2));
+    else
+        error('Please input correct motionType (integer from 0 to 4)')
+    end
+    
+    thres = threshTab.thresholds(cellNo);
+    
+else
+    xDat = TRI(:,1);
+    yDat = TRI(:,2);
+    thres = TRI(1,3);
+    
+end % (if iscell(TRI))
+
+x = min(xDat):(max(xDat)-min(xDat))/100:max(xDat);
+x2lineBelow = min(xDat):(thres-min(xDat))/100:thres;
+x2lineAbove = thres:(max(xDat)-thres)/100:max(xDat);
+
+if ~isempty(scalingFactor)
+    xDat = xDat*scalingFactor(1);
+    yDat = yDat*scalingFactor(2);
+    thres = thres*scalingFactor(1); %thres belongs to the x-axis
+end
+
+% Plot scatter and plot lines:
+figure; scatter(xDat,yDat); hold on
+
+% If there is no valid threshold, plot only scatter, no lines.
+if isempty(threshTab.coefsOfMin{cellNo}) || any(any(isnan(threshTab.coefsOfMin{cellNo})))
+    title(['Cell ' num2str(cellNo) ' ' figStr ' no threshold'])
+    return
+end
+
+y1line = threshTab.coefsOfMin{cellNo}(1,3) + threshTab.coefsOfMin{cellNo}(2,3)*x;
+yBelow = threshTab.coefsOfMin{cellNo}(1,1) + threshTab.coefsOfMin{cellNo}(2,1)*x2lineBelow;
+yAbove =  threshTab.coefsOfMin{cellNo}(1,2) +  threshTab.coefsOfMin{cellNo}(2,2)*x2lineAbove;
+
+if ~isempty(scalingFactor)
+    y1line = y1line*scalingFactor(2);
+    yBelow = yBelow*scalingFactor(2);
+    yAbove = yAbove*scalingFactor(2);
+    
+    x = x*scalingFactor(1);
+    x2lineBelow = x2lineBelow*scalingFactor(1);
+    x2lineAbove = x2lineAbove*scalingFactor(1);
+end
+
+plot(x2lineBelow,yBelow,'r') % plot line below
+plot(x2lineAbove,yAbove,'r') % plot line above
+plot(x,y1line,'k') % plot 1 line
+
+xline(thres,'--r') % plot biphasic threshold
+
+title(['Cell ' num2str(cellNo) ' ' figStr])
+
+end

--- a/retainSmPropInMask.m
+++ b/retainSmPropInMask.m
@@ -1,0 +1,93 @@
+function smPropPerTimeIntInMask = retainSmPropInMask(smPropPerTimeIntAll, threshMet, numOutsideMaskFlag)
+% RETAINSMPROPINMASK: takes the properties of SMI per FSM interval and the indexes of which SMI tracklet is within mask and discard those tracklets that are outside of the mask.
+%
+% SYNOPSIS: smPropPerTimeIntInMask = retainSmPropInMask(smPropPerTimeIntAll, threshMet)
+%
+% EXAMPLE: smPropPerTimeIntInMask = retainSmPropInMask(smPropPerTimeIntSpan2000_tmp, threshMetSpan2000_tmp);
+%
+% INPUT: smPropPerTimeIntAll: (cell array) SMI properties per interval,
+%                             with all tracklets include information both
+%                             inside and outside of mask. See
+%                             smPropPerTimeInterval.m output for details. 
+%
+%                  threshMet: (n x 1 cell vectors) contains SM indices that 
+%                             exists within cell ROI masks from qFSM.
+%
+%         numOutsideMaskFlag: (logical) Sanity check flag to display number
+%                             of SM being removed due to being outside the
+%                             mask. Default: 0 (no display)
+%
+% OUTPUT: smPropPerTimeIntInMask: similar to input smPropPerTimeIntAll but
+%                             containing only SM tracklets within mask.
+%
+% Tra Ngo, Mar 2023
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Input:
+numMov = size(smPropPerTimeIntAll,1);
+numMask= size(threshMet,1);
+if numMov ~= numMask
+    error('Inconsistent inputs. Number of masks and movies must match.')
+end
+if ~exist('numOutsideMaskFlag','var') || isempty(numOutsideMaskFlag) 
+    numOutsideMaskFlag = false;
+end
+
+
+%% Output initialization:
+smPropPerTimeIntInMask = cell(numMov,1);
+
+for i = 1:numMov
+    
+    fnames = fieldnames(smPropPerTimeIntAll{i});
+    
+    for iFr = 1:size(smPropPerTimeIntAll{i},1) % loop through each interval
+        
+        for iFl = 1:length(fnames)
+            
+            switch fnames{iFl}
+                case {'smFrames','maskDensity','mergeInfoSpace','splitInfoSpace'}
+                    % 'maskDensity' is copied because it is already calculated as number of valid SM tracklets / area of mask
+                    % merge and split information is copied because it is independent from SM track as well
+                    smPropPerTimeIntInMask{i}(iFr,1).(fnames{iFl}) = smPropPerTimeIntAll{i}(iFr,1).(fnames{iFl});
+                otherwise
+                    smPropPerTimeIntInMask{i}(iFr,1).(fnames{iFl}) = smPropPerTimeIntAll{i}(iFr,1).(fnames{iFl})(threshMet{i}{iFr},:);
+                    
+                    % Sanity check:
+                    if numOutsideMaskFlag
+                        switch fnames{iFl}
+                            case{'smList'}
+                                disp(['Number of SM outside mask for movie ' num2str(i) ...
+                                    ' frame ' num2str(iFr) ': ' num2str(max(smPropPerTimeIntAll{i}(iFr,1).(fnames{iFl})) ...
+                                    - length(threshMet{i}{iFr}))])
+                        end
+                    end
+
+            end
+            
+        end % for iFl = 1:length(fnames)
+        
+    end % for iFr = 1:size(smPropPerTimeIntAll{i},1)
+    
+end % for i = 1:numMov
+
+
+end

--- a/retainTassmInliers.m
+++ b/retainTassmInliers.m
@@ -1,0 +1,193 @@
+function [tassmInl, flagInl, tassmInlFollower1Out, tassmInlFollower2Out] = ...
+    retainTassmInliers(tassmMaster, thresholds, tassmFollower1, tassmFollower2)
+%RETAINTASSMINLIERS: search for and NaN out outliers in each column of tassm
+%
+%INPUT:  tassmMaster : (array of n cells), each cell contains 3 cells:
+%                    .1st cell contains matrix property for speckle.
+%                    .2nd cell contains matrix property for single-molecule.
+%                    .(optional) 3rd cell contains matrix for mean position of
+%                    single-molecule. 
+%
+%        thresholds: (1x2 cell) with 1st cell contains vector of threshold
+%                    outlier detection for each column in speckle property (i.e.
+%                    tassm{i}{1,1}) and 2nd cell contains vector of threshold outlier
+%                    detection for each column in single-molecule property (i.e.
+%                    tassm{i}{1,2}). If value is NaN, no outlier detection is done on
+%                    that column.
+%                    Example: thresholds = {[3  NaN  2.5  NaN  4  2.5  2  1.5  2.5] [6  7  2  NaN  NaN  NaN  NaN]};
+%
+%      tassmFollower1: (optional) similar structure to first input: tassm, but is  
+%                    the results from actinPropPerTimeInterval where any
+%                    matrix entries with incomplete lifetimes replaced by 
+%                    NaN. (see related function cleanActinPropPerTimeInt.m)
+%                    Example: tassmClnSpeedLft
+%                    If not input, corresponding output is [].
+%
+%      tassmFollower2: (optional) similar structure to first input: tassm, but is the
+%                    results from actinPropPerTimeInterval where any matrix
+%                    entries with speeds below threshold replaced by 0.
+%                    (see related function cleanActinPropPerTimeInt.m)  
+%                    Example: tassmClnSpeed
+%                    If not input, corresponding output is [].
+%
+%OUTPUT: tassmInl  : tassm with inliers only retained. Outliers are NaN out.
+%
+%        flagInl   : (similar structure with tassm) flag of inliers (1 =
+%                    inlier, 0 = outlier)
+%
+%       tassmInlFollower1Out: similar structure to first output: tassmInl, 
+%                    where output flagInl is applied on input tassmClnSpeedLft.
+%                    Example: tassmInlClnSpeedLft
+%
+%       tassmInlFollower2Out: similar structure to first output: tassmInl, 
+%                    where output flagInl is applied on input tassmClnSpeed.
+%                    Example: tassmInlClnSpeed
+%
+% Tra Ngo, July 2021
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Input
+numCell = length(tassmMaster);
+if length(thresholds) ~=2
+    error('Input thresholds expects 1x2 cell.');
+end
+
+% Check if user only input master tassm (for backward compartibility
+% because follower tassm was added later - TN20210716)
+if nargin == 2 % (only master tassm was input)
+    
+    followerTassmCase = 0;
+    
+elseif nargin == 3 % (if master and only follower 1 were input)
+    followerTassmCase = 1;
+    % Check that the multiple inputs are of the same tassm size
+    numCellFollower1 = length(tassmFollower1);
+    if numCellFollower1 ~= numCell
+        error('1st and 3rd input must have the same length.')
+    end
+    
+elseif nargin == 4 % (if master and 2 followers were input)
+    followerTassmCase = 2;
+    % Check that the multiple inputs are of the same tassm size
+    numCellFollower1 = length(tassmFollower1);
+    numCellFollower2 = length(tassmFollower2);
+    if numCellFollower1 ~= numCell || numCellFollower2 ~= numCell
+        error('1st, 3rd, and 4th input must have the same length.')
+    end
+    
+else
+    
+    error('Function expects at least 2 inputs.')
+    
+end
+
+
+%% Output:
+tassmInl = tassmMaster;
+switch followerTassmCase
+    case 2 % when 2 followers are input
+        tassmInlFollower1Out = tassmFollower1;
+        tassmInlFollower2Out = tassmFollower2;
+    case 1 % when 1 follower is input
+        tassmInlFollower1Out = tassmFollower1;
+        tassmInlFollower2Out = [];
+    case 0 % when 0 follower is input, only master
+        tassmInlFollower1Out = [];
+        tassmInlFollower2Out = [];
+end
+
+flagInl =  cell(numCell, 1);
+for i = 1:numCell
+    try
+        flagInl{i}{1,1} = true(size(tassmMaster{i}{1,1}));
+        flagInl{i}{1,2} = true(size(tassmMaster{i}{1,2}));
+    catch
+        warning(['Check if tassm of cell ' num2str(i) ' is empty.'])
+    end
+end
+
+%% Looping through each cell:
+for iC = 1:numCell
+    
+    if isempty(tassmMaster{iC,1}) % skip a cell if its tassm doesn't exist
+        continue
+    end
+    
+    % looping through speckle property (iP = 1) & single-molecule property (iP = 2)
+    for iP = 1:2
+        
+        tmpThrLen = length(thresholds{iP});
+        tmpMatLen = size(tassmMaster{iC,1}{1,iP},2);
+        
+        if tmpMatLen ~= tmpThrLen
+            error(['Vector length of input thresholds for cell ' num2str(iC) ' needs to be similar to number of column of corresponding tassm matrix.'])
+            
+        else
+            
+            % looping through each threshold vector
+            for iCurr = 1:tmpThrLen
+                
+                threshCurr = thresholds{iP}(iCurr);
+                
+                if isnan(threshCurr) % skip a cell if its threshold is NaN
+                    continue
+                end
+                
+                data_withNan = tassmMaster{iC,1}{1,iP}(:,iCurr);
+                
+                % remove nan from data
+                indxNan = isnan(data_withNan);
+                data = data_withNan(~indxNan);
+                
+                % detect outlier
+                outlierIdx_noNan = isoutlier(data,'quartiles','ThresholdFactor',threshCurr);
+                
+                % Map the outlier indices back to the original vector
+                originalOutlierIdx = find(~indxNan); % indices of non-NaN elements
+                originalOutlierIdx = originalOutlierIdx(outlierIdx_noNan); % get indices of outliers in original vector
+                
+                outlierIdx = false(length(data_withNan),1);
+                outlierIdx(originalOutlierIdx) = true;
+                
+                % Output inlier flags: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                flagInl{iC}{1,iP}(outlierIdx,iCurr) = false;
+                
+                % Output tassmInl: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                tassmInl{iC}{1,iP}(outlierIdx,iCurr) = NaN;
+                
+                %% Apply flagInl onto tassmClnSpeedLft, tassmClnSpeed: (NaN out outliers)
+                switch followerTassmCase
+                    case 2
+                        tassmInlFollower1Out{iC}{1,iP}(outlierIdx,iCurr) = NaN;
+                        tassmInlFollower2Out{iC}{1,iP}(outlierIdx,iCurr) = NaN;
+                    case 1
+                        tassmInlFollower1Out{iC}{1,iP}(outlierIdx,iCurr) = NaN;
+                end % (if followerTassmFlag)
+                
+            end % (for iCurr = 1:tmpThrLen)
+            
+        end % (if tmpMatLen ~= tmpThrLen)
+        
+    end % (for iP = 1:2)
+    
+end % (for iC = 1:numCell)
+
+end

--- a/runSmactinAggMovExplain.m
+++ b/runSmactinAggMovExplain.m
@@ -1,0 +1,252 @@
+function outputStruct = runSmactinAggMovExplain(tassm,matchindx,smactinFlag, propSpk, propSm, ...
+    maxNumPropVect, mvrgAggMatFlag, cutOffInput, outlierParam, spekLabelBase, smLabelBase, sigThreshInput)
+%RUNSMACTINAGGMOVEXPLAIN takes data matrices of SM - speckles pairs, perform MVRG on them, and report statistical significances of the regression coefficients.
+%
+%SYNOPSIS: outputStruct = runSmactinAggMovExplain(tassm,matchindx,smactinFlag, propSpk, propSm, ...
+%                         maxNumPropVect, mvrgAggMatFlag, cutOffInput, outlierParam, spekLabelBase, ...
+%                         smLabelBase, sigThreshInput)
+%
+%PROCESS: runSmactinAggMovExplain.m takes individual data matrices from tassm, 
+% call smactinAggMov.m for individual cells, split its result into "above" and 
+% "below" populations, and run subsequent explaination functions of the MVRGs.
+%
+%INPUT: tassm           : (n x 1 cell array of cells) Each cell contains 3 x 1 
+%                         cells, containing data matrix of SM tracklets and 
+%                         speckle properties:
+%                       Cell {1,1}: (k observations x 9 properties) Data 
+%                       matrix of speckle properties with columns as:
+%                               1: Local speckle displacement magnitude
+%                               2: Speckle co-movement
+%                               3: Local speckle density 
+%                               4: Speckle lifetime
+%                               5: Local speckle intensity
+%                               6: Local speckle background intensity
+%                               7: speckle corrected intensity
+%                               8: speckle corrected background intensity
+%                               9: Local speckle average displacement magnitude
+%                       Cell {2,1}: (k observations x 7 properties) Data 
+%                       matrix of SM properties with columns as:
+%                               1: SM net speed
+%                               2: SM intensity
+%                               3: SM diffusion coefficient
+%                               4: SM density
+%                               5: SM spatial span
+%                               6: SM apparent assembly state (oligomerization state)
+%                               7: SM mss Slope (added TN Jan2023)
+%                               8 - 13: from Mode analysis, added TN Mar2024
+%                               8: SM Diffusion coefficient from mean square F2F displacement 
+%                               9: SM Diffusion radius
+%                               10: SM Mean square F2F displacement 
+%                               11: SM Mean positional standard deviation
+%                               12: SM lifetime
+%                               13: SM Mode (1, 2, ...) <- VERY IMPORTANT CONSTANT
+%                               14: SM diffusion type (motion classification by MSS)
+%                       See smactinMat.m for details.
+%
+%        matchindx      : indices of speckles,ks, or sms matching to an object;
+%                         empty if many neighbors matching is performed.
+%                       See smactinMat.m for details.
+%
+%        smactinFlag    : (structure) flags describing the method by which 
+%                         SM tracklets and actin speckles are associated
+%                         spatially; contains the following field: 
+%                               .combFlag: integer with value either 7 (to 
+%                                 match SM to speckles based on average SM
+%                                 position) or 10 (to match SM to speckles
+%                                 based on frame-by-frame SM position).
+%                               .randFlag: (integer) must put value > 0.
+%
+%        propSpk        : (vector of interger) of speckle properties in tassm
+%                         collected for normAggMat. (optional) If input as
+%                         empty [] then default to [1 3 4].
+%                         See smactinAggMov.m for details.
+%
+%        propSm         : (vector of interger) of SM properties in tassm
+%                         collected for normAggMat. (optional) If input as
+%                         empty [] then default to [2 3 4].
+%                         See smactinAggMov.m for details.
+%
+%        maxNumPropVect : (1x2 vector) number of speckle property in tassm
+%                         and number of SM property in tassm. 
+%
+%        mvrgAggMatFlag : (logic, optional) flag indicating whether
+%                         normalization should be performed before MVRG.
+%                         default. 0 = MVRG on normAggMat. (normalized data)
+%                                  1 = MVRG on aggMat. (original data;
+%                                      cutting through intercept [oneVect X-data])
+%
+%        cutOffInput    : (1x2 vector, optional) threshold at which data is 
+%                        split into 2 subsets before any MVRG and
+%                        statistical analysis.
+%                        (default) empty [] -> data not split into 2.
+%                        1st entry: threshold dividing the data into 2.
+%                        2nd entry: the column in .aggMat that the threshold 
+%                        is scanned within, to split the data into 2.
+%                        Example: cutOffInput = [0.01 3];
+%
+%        outlierParam   : (4 x 1 vector, optional) Parameters for outlier
+%                        detection process, containing in order:
+%                        [neighborNum, iterThres, maxIter, k]. If [] is
+%                        input, default to [2 0.1 4 -1] (empirically determined).
+%                        See smactinAggMov.m for details.
+%
+%        spekLabelBase  : (1 x n cell array) each cell contains name of 
+%                        speckle property to be plotted on the x-axis.
+%                        See explainIndCellsMvrgWithRand.m for details.
+%
+%        smLabelBase    : (1 x n cell array) each cell contains name of SM 
+%                        property for plot title.
+%                        See explainIndCellsMvrgWithRand.m for details.
+%
+%        sigThreshInput : (1x2 double vector, optional) alpha thresholds 
+%                        that determine whether p-values are significant. 
+%                        [alpha-value for ttest , alpha-value for randomization test] 
+%                        Optional. If empty [] was input, default to [0.05, 0.05].
+%
+%
+% ------- example inputs -------
+% smactinFlag = struct('combFlag',10,'randFlag',100, 'match',2, 'synthData',0);
+% propSpk = [1 3 4 5]; % speed, density, lifetime, ilmax
+% propSm = [2 3 4]; % mean amp, diff coef, density
+% maxNumPropVect = [9 6]; % 9 speckle props, 6 sm props
+% mvrgAggMatFlag = 0; % MVRG done on normAggMat
+% cutOffInput = [0.01 3]; % threshold on actin density at 0.01
+% outlierParam = [2 0.1 4 -1]; % -1 for not running any outlier detection
+% sigThreshInput = [0.05 0.05];
+% spekLabelBase = {'Speckle Speed','Speckle Local Density','Speckle Lifetime'};
+% smLabelBase = {'SM Mean Amplitude','SM Diff Coef','SM Local Density'};
+% ------------------------------
+%
+%OUPUT: Function outputs 2 folders: "above" and "below" that contain
+%       box-plot of regression coefficients from MVRG performed on data 
+%       above and below the user-input threshold, respectively.
+%
+%       outputStruct: (structure) results of MVRG and relevant statistical 
+%                     analyses relating to comparing MVRG coefficients;
+%                     contains the following fields:
+%                     .testResultAndSplit: MVRG results of all input data
+%                               and of any subsets of data below and above 
+%                               the user-input threshold.
+%                               See smactinAggMov.m for details.
+%                     .trajClassAndInputParam: {1,1} contains SM track's
+%                               diffusion type (See smactinAggMov.m for
+%                               details); {1,2} contains input parameters
+%                               of this function.
+%                               See smactinAggMov.m for details.
+%                     .testResultSplitAbv: MVRG results of subset of data
+%                               above the user-input threshold.
+%                               See smactinAggMov.m for details.
+%                     .testResultSplitBel: MVRG results of subset of data
+%                               below the user-input threshold.
+%                               See smactinAggMov.m for details.
+%                     .explainIndCellsMvrgWithRand_abv: significances for
+%                               MVRG results of randomized data of
+%                               individual cells, for data above the
+%                               user-input threshold.
+%                               See explainIndCellsMvrgWithRand.m for details.
+%                     .explainIndCellsMvrgWithRand_bel: significances for
+%                               MVRG results of randomized data of
+%                               individual cells, for data below the
+%                               user-input threshold.
+%                               See explainIndCellsMvrgWithRand.m for details.
+%                     .explainIndCellsMVRG_abv: significances and outliers
+%                               of MVRG coefficients, for data above the
+%                               user-input threshold.
+%                               See explainIndCellsMVRG.m for details.
+%                     .explainIndCellsMVRG_bel: significances and outliers
+%                               of MVRG coefficients, for data below the
+%                               user-input threshold.
+%                               See explainIndCellsMVRG.m for details.
+%
+%GLOSSARY:  SMI   : single molecule imaging
+%           SM    : single molecule
+%           FSM   : fluorescent speckle microscopy
+%           tassm : total attributes speckles and single molecules
+%           MVRG  : multivariate regression
+%
+%Tra Ngo, Aug 2021
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Inputs & initialize variables
+len = length(tassm);
+if isempty(matchindx)
+    matchindx = cell(len,1);
+end
+
+testResult = cell(len,1);
+trajClass = cell(len,1);
+testResultSplit = cell(len,1);
+inputParam = cell(len,1);
+
+%% Run MVRG analysis for each cell ROI/movie
+for i = 1:len
+    disp(['Mov: ' num2str(i)])
+    [testResult{i,1},trajClass{i,1}, testResultSplit{i,1}, inputParam{i,1}] = ...
+        smactinAggMov(tassm(i),matchindx(i),smactinFlag, ...
+        propSpk, propSm, maxNumPropVect, mvrgAggMatFlag, cutOffInput, outlierParam); 
+end
+
+testResultSplitAbv = cell(len,1);
+testResultSplitBel = cell(len,1);
+for i = 1:len
+    testResultSplitAbv{i,1} = testResultSplit{i,1}(:,1);
+    testResultSplitBel{i,1} = testResultSplit{i,1}(:,2);
+end
+
+
+outputStruct.testResultAndSplit{1} = testResult;
+outputStruct.testResultAndSplit{2} = testResultSplit;
+
+outputStruct.trajClassAndInputParam{1} = trajClass;
+outputStruct.trajClassAndInputParam{2} = inputParam;
+
+outputStruct.testResultSplitAbv = testResultSplitAbv;
+outputStruct.testResultSplitBel = testResultSplitBel;
+
+[belowThreshFlag3D_abv, fraction3D_abv, avgPval_abv, coefMat4D_abv] = explainIndCellsMvrgWithRand(testResultSplitAbv, spekLabelBase, smLabelBase, sigThreshInput);
+[belowThreshFlag3D_bel, fraction3D_bel, avgPval_bel, coefMat4D_bel] = explainIndCellsMvrgWithRand(testResultSplitBel, spekLabelBase, smLabelBase, sigThreshInput);
+
+outputStruct.explainIndCellsMvrgWithRand_abv{1} = belowThreshFlag3D_abv; 
+outputStruct.explainIndCellsMvrgWithRand_abv{2} = fraction3D_abv; 
+outputStruct.explainIndCellsMvrgWithRand_abv{3} = avgPval_abv; 
+outputStruct.explainIndCellsMvrgWithRand_abv{4} = coefMat4D_abv; 
+
+outputStruct.explainIndCellsMvrgWithRand_bel{1} = belowThreshFlag3D_bel; 
+outputStruct.explainIndCellsMvrgWithRand_bel{2} = fraction3D_bel; 
+outputStruct.explainIndCellsMvrgWithRand_bel{3} = avgPval_bel; 
+outputStruct.explainIndCellsMvrgWithRand_bel{4} = coefMat4D_bel; 
+
+mkdir above; cd above
+[pSigTtest_abv, outlierIndx_abv, randResult_abv, mvrgCoef_abv] = explainIndCellsMVRG(testResultSplitAbv, spekLabelBase, smLabelBase, sigThreshInput);
+cd ..; mkdir below; cd below
+[pSigTtest_bel, outlierIndx_bel, randResult_bel, mvrgCoef_bel] = explainIndCellsMVRG(testResultSplitBel, spekLabelBase, smLabelBase, sigThreshInput);
+cd ..
+
+outputStruct.explainIndCellsMVRG_abv{1} = pSigTtest_abv; 
+outputStruct.explainIndCellsMVRG_abv{2} = outlierIndx_abv; 
+outputStruct.explainIndCellsMVRG_abv{3} = randResult_abv; 
+outputStruct.explainIndCellsMVRG_abv{4} = mvrgCoef_abv;
+
+outputStruct.explainIndCellsMVRG_bel{1} = pSigTtest_bel; 
+outputStruct.explainIndCellsMVRG_bel{2} = outlierIndx_bel; 
+outputStruct.explainIndCellsMVRG_bel{3} = randResult_bel; 
+outputStruct.explainIndCellsMVRG_bel{4} = mvrgCoef_bel;
+end

--- a/scan4smSpeckleThreshold.m
+++ b/scan4smSpeckleThreshold.m
@@ -1,0 +1,815 @@
+function [thresholdsTable, inputParam, varOfResid, evalInfoBIC, biphasicThreshArr, stat, nonVshapeList, randPlotData] = ...
+    scan4smSpeckleThreshold(tassm, matchindx, smactinFlag, scanInfo, motionType, figureInfo, scanParamArray)
+%SCAN4SMSPECKLETHRESHOLD checks whether 1-line or 2-line fit describes the input data better
+%
+%SYNOPSIS:  [thresholdsTable, inputParam, varOfResid, evalInfoBIC, biphasicThreshArr, stat, nonVshapeList, randPlotData] = ...
+%    scan4smSpeckleThreshold(tassm, matchindx, smactinFlag, scanInfo, motionType, figureInfo, scanParamArray)
+%
+%INPUT:     tassm      : (n x 1 cell array) data matrix of SM and actin properties.
+%                        See smactinMat.m for details.
+%
+%           matchindx  : indices of speckles,ks, or sms matching to an object;
+%                        empty if many neighbors matching is performed.
+%                        See smactinMat.m and smactinAggMov.m for details.
+%
+%           smactinFlag: (structure) flags indicating methods of SMI-FSM
+%                        combination. IMPORTANT: Field .randFlag should be
+%                        set to 0 so that no unnecessary randomization is
+%                        done within MVRG analysis. 
+%                        See smactinPropPerTimeInt.m for details.
+%
+%           scanInfo   : (1x2 vector, double) values of thresholds to be tested
+%                      scanInfo(1) : column index of dividing speckle
+%                                    properties) (i.e. 3 = speckle density)
+%                      scanInfo(2) : step size of scanning values (i.e. 0.0005)
+%
+%           motionType : (integer, optional) diffusion type to analyse. 
+%                       = 0 : immobile
+%                       = 1 : confined brownian
+%                       = 2 : pure brownian (free diffusion)
+%                             If input [], default to 2 (free).
+%                       = 3 : directed motion  
+%
+%           figureInfo : (1 x 4 cell array) Flag indicating whether figures
+%                        will be output or not.
+%                       Cell {1}: (logic) 1 (Default) = output figures & save
+%                                them in current directory under file
+%                                names: '2lineOver1_.fig'; 'varmin_1_.fig';
+%                                'varmin_2_.fig'.
+%                                0 = no output figures;
+%                       Cell {2}: (char) string to be included in figure's name
+%                                for saving .fig into current directory.
+%                       Cell {3}: (logic) 1 = output figures of 1 randomized data
+%                                example & save them in current directory
+%                                under file names: 'scatterRandData_.fig';
+%                                0 (Default) = not output figures;
+%                       Cell {4}: (logic) 1 = output figures of real data &
+%                                save them in current directory under file 
+%                                names: 'scatterRealData_.fig';
+%                                0 (Default) = not output figures;
+%
+%           scanParamArray: (1x4 cell array) (FKA propStruct) Indication of 
+%                           which property to perform analysis on:
+%                       {1}: property column index of speckle, i.e = [3]
+%                       {2}: property column index of SM, i.e = [3]
+%                       {3}: max number of property: (1x2 vector) number of speckle
+%                            property and number of SM property in tassm.
+%                            i.e = [9 6]
+%                       {4}: outlier parameters (4x1 vector), i.e  = [2 0.1 4 -1]
+%                       See smactinAggMov.m for details.
+%                       {5}: bootstrapping flag. Optional. Default = 0 (no
+%                       	 bootstrap). If = M, then M bootstrap is
+%                       	 performed on data (random sampling with
+%                       	 replacement is done before performing biphasic
+%                       	 analysis.) -- this option is obsolete.
+%
+%OUTPUT:     thresholdsTable: (table) reporting at which thresholds is fit
+%                             variance at minimum, include the following column:
+%                       .thresholds      : threshold at which 2-line fit has min variance
+%                       .minVar          : variance of 2-line fit at listed threshold 
+%                       .vShapeFlagFinal : final decision flag indicating
+%                                          if 2-line fit describes the data
+%                                          better than the 1-line fit (1)
+%                                          or not (0).
+%                       .vShapeFlagReal  : flag indicating if the 2-line
+%                                          fit describes the real data
+%                                          better than the 1-line fit (1)
+%                                          or not (0).
+%                       .vShapeFlagRand  : flag indicating if the 1-line
+%                                          fit describes the randomized
+%                                          data better than the 2-line fit
+%                                          m < M times (1) or not (0). M is
+%                                          hardcoded to 5. 
+%                       .vShapeNumRand   : m from .vShapeFlagRand.
+%                       .valBICvShape    : BIC value of 2-line fit.
+%                       .valBICline      : BIC value of 1-line fit.
+%                       .edgeFlag        : flag indicating whether the
+%                                          listed threshold is at the edge
+%                                          of all scanned thresholds (1) or
+%                                          not (0).
+%                       .coefsOfMin      : regression coefficients, each
+%                                          entry is a 2x3 matrix. row 1 =
+%                                          y-intercept; row 2 = slope.
+%                               col1 = below threshold (2-line fit at listed threshold)
+%                               col2 = above threshold (2-line fit at listed threshold)
+%                               col3 = total data population (1-line fit)
+%
+%             inputParam     : input parameters.
+%
+%             varOfResid     : variance of residues from regression of both
+%                              population, calculated after grouping the
+%                              residues from both population.
+%                              Cols: different thresholds;
+%                              Row: different cells
+%                              = nansum((residuals-resMean).^2)/(n-1);
+%
+%             evalInfoBIC    : (Cells) each contains matrix where:
+%                              Rows = different movies/cell ROIs
+%                              Cols = different thresholds that were scanned
+%                            {1,1}: (logical matrix) indicating if 2-line
+%                                   (1) describe the data better 1-line fit 
+%                                   (0) based on BIC.
+%                            {1,2}: (matrix) BIC value of 2-line fit
+%                            {1,3}: (matrix) BIC value of 1-line fit
+%
+%           biphasicThreshArr: array of thresholds of movies that are
+%                             deemed biphasic & not biphasic in randomized
+%                             case.
+%
+%               stat         : (1x4 vector) statistics of biphasic behavior.
+%                              1st 3 entries: [mean, median, std] of biphasicThreshArr.
+%                              4th entry = percentage of cells that passed
+%                              biphasic tests out of cells input in tassm.
+%
+%               nonVshapeList: (matrix) index(es) of cells that failed all
+%                              the biphasic criteria.
+%
+%               randPlotData : (n x 2 array of cell) Column 1 is a nx3
+%                              matrix of data plotted for the randomized
+%                              scatter plot & the corresponding threshold.
+%                              Column 2 is a 2x3 matrix of slopes (row2) and 
+%                              intercepts (row1) of fits below the
+%                              threshold (col1), above threshold (col2),
+%                              and over all data (col3) (similar to
+%                              .coefsOfMin in output table.)
+%                              This is only output when figureInfo{3} = true.
+%                              
+%
+%PROCESS: thresholds are automatically determined within the code so that
+%there are sufficient data for 2-line fit to be performed. Fits are
+%determined by visualizing residual sum of squares of regression for the
+%data below & above the user-input threshold.
+%
+%GLOSSARY:  SMI   : single molecule imaging
+%           SM    : single molecule
+%           FSM   : fluorescent speckle microscopy
+%           tassm : total attributes speckles and single molecules
+%           BIC   : Bayesian Information Criterion
+%
+%EXAMPLE INPUTS:
+%               smactinFlag = struct('combFlag',10,'randFlag',0, 'match',2, 'synthData',0); 
+%               scanInfo = [3 0.0005];
+%               motionType = 1;
+%               figureInfo = {1, 'CD36',1, 1};
+%               scanParamArray = {3, 3, [9 6], [2 0.1 4 -1], 10};
+%
+%Tra Ngo, July 2020. Modified August 2021.
+%REMARK: In the future, need to load/create default matchindx and smactinFlag
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Input control, Initialization & constants
+if ~exist('motionType','var') || isempty(motionType)
+    motionType = 2;
+end
+
+if ~exist('figureInfo','var') || isempty(figureInfo)
+    figureFlag = 1;
+    figIdentifier = '';
+    flagRandFig = 0;
+    flagRealFig = 0;
+elseif length(figureInfo) == 1
+    figureFlag = figureInfo{1};
+    figIdentifier = '';
+    flagRandFig = 0;
+    flagRealFig = 0;
+elseif length(figureInfo) == 2
+    figureFlag = figureInfo{1};
+    figIdentifier = figureInfo{2};
+    flagRandFig = 0;
+    flagRealFig = 0;
+elseif length(figureInfo) == 3 % TN20220317
+    figureFlag = figureInfo{1};
+    figIdentifier = figureInfo{2};
+    flagRandFig = figureInfo{3};
+    flagRealFig = 0;
+elseif length(figureInfo) == 4 % TN20220317
+    figureFlag = figureInfo{1};
+    figIdentifier = figureInfo{2};
+    flagRandFig = figureInfo{3};
+    flagRealFig = figureInfo{4};
+else
+    error('Input "figureInfo" expects either 1x2 or 1x3 cell array or empty.') % TN20210816
+end
+
+if ~exist('scanParamArray', 'var') || isempty(scanParamArray)
+    error('scanParamArray of 1x5 (or 1x4) cell array must be input.')
+else
+    propSpek = scanParamArray{1}; % i.e. propSpek = [3]; % just speckle actin
+    propSM = scanParamArray{2}; % i.e. propSM = [3]; % just SM diffusion coefficients
+    maxNumSpklProp = scanParamArray{3}; % i.e. maxNumSpklProp = [9 6]; % ILmax, IBkg, ILmaxCorrected, IBkgCorrected, averageSpeed incorporated (TN20211025)
+    outlierParam = scanParamArray{4}; % i.e. outlierParam = [2 0.1 4 -1]; (-1 so outlier detection is not performed here)
+    
+%     if length(scanParamArray) < 5
+%         bootstrapNum = 0;
+%     else
+%         bootstrapNum = scanParamArray{5}; % i.e. bootstrapNum = 10;
+%     end
+    
+end
+
+if ~exist('scanInfo','var') || isempty(scanInfo) || length(scanInfo) ~= 2
+    error('Input "scanValues" expects 1x2 vector: [divPropIndx, scanValSteps].')
+else
+    divPropIndx = scanInfo(1);
+    scanValSteps = scanInfo(2);
+end
+
+nRandom = 100; % number of randomized tassm
+tolRand = 5; % tolerance for number of randomization that can be vShape (if randomized data
+% is vShape more than 5 times i.e. 6, that cell would not be considered a genuine vShape.)
+
+scanValMat = [];
+numCell = length(tassm);
+
+if isempty(matchindx)
+    matchindx = cell(numCell,1);
+end
+
+%% Output initialization
+inputParam = {smactinFlag, scanInfo, motionType, figureFlag, scanParamArray};
+thresholdsTable = array2table(zeros(0,0));
+
+randPlotData = cell(numCell,2); % only filled in this output if flagRandFig == 1
+testResultsIndx = cell(numCell,1);
+
+%% Get scanValues ensuring each side of threshold must have 15% (const minDatPerc) of total data
+minVal = NaN; maxVal = NaN;
+boundMat = cell(numCell,1);
+for iCell = 1:numCell
+    if isempty(tassm{iCell})
+        continue
+    end
+    motionVect = tassm{iCell}{1,2}(:,end); % SM motion type
+    indxMotionType = motionVect == motionType; % indexing which row if of motion type of interest
+    spkProp = tassm{iCell}{1,1}(indxMotionType, divPropIndx);
+    % NOTE: (TN20220919) Density of 0, even though not counted towards MVRG
+    % analysis, is still counted here as number of datapoint to determine
+    % the threshold. i.e., if dataMat has 15 datapoint with density = 0,
+    % then threshold would start at 0.
+    
+    minDatPerc = 0.15; % each side of threshold must have at least 15% of total data
+    %boundMat{iCell,1} = round(quantile(spkProp,[minDatPerc (1-minDatPerc)]),5); % quantile calls prctile, also run a bit slower than prctile
+    boundMat{iCell,1} = round(prctile(spkProp,[minDatPerc*100 (1-minDatPerc)*100]),5); % same output with quantile call above
+    
+    minVal = min(minVal, boundMat{iCell,1}(1));
+    maxVal = max(maxVal, boundMat{iCell,1}(2));
+end
+
+scanValues = (minVal: scanValSteps :maxVal);
+numThresh = length(scanValues);
+
+vShapeFlag   = nan(numCell, numThresh);
+valBICvShape = nan(numCell, numThresh);
+valBICline   = nan(numCell, numThresh);
+varOfResid = nan(numCell, numThresh);
+varianceLine = nan(numCell, numThresh);
+scanValMat   = nan(numCell, numThresh);
+coefArr = cell(numCell, numThresh);
+
+for iScan = 1:numThresh
+    %% Threshold of consideration in this loop
+    cutoffInput = [scanValues(iScan) divPropIndx];
+    scanValMat(:,iScan) = ones(numCell,1) * scanValues(iScan); % for plotting
+    
+    for iCell = 1:numCell
+        
+        if isempty(boundMat{iCell,1}) || scanValues(iScan) < boundMat{iCell,1}(1) || scanValues(iScan) > boundMat{iCell,1}(2)
+            % for current cell, if the scan value is outside the range to
+            % search for threshold (where the majority of the data is), then
+            % continue to the next cell.
+            vShapeFlag(iCell, iScan)   = NaN;
+            valBICvShape(iCell, iScan) = NaN;
+            valBICline(iCell, iScan)   = NaN;
+            varOfResid(iCell, iScan) = NaN;
+            varianceLine(iCell, iScan) = NaN;
+            coefArr{iCell, iScan} = NaN;
+            
+        else
+            
+            % Regression of individual cell with each threshold (from scanValues input) via smactinAggMov
+            [testResultsIndx{iCell}, ~, testResultCutOff{iCell}, inPar] = ...
+                smactinAggMov(tassm(iCell), matchindx(iCell),smactinFlag, ...
+                propSpek, propSM, maxNumSpklProp, 1, cutoffInput, outlierParam);
+            % mvrgAggMatFlag = 1 because we observe biphasic on raw data and we only regress on 1 property vs 1 other property
+            
+            [vShapeFlagTmp, valBICvShapeTmp, valBIClineTmp, varOfResidTmp, varLineTmp, coefTmp] = ...
+                getBicAndVarResFrMvrg(testResultsIndx{iCell}, testResultCutOff{iCell}, motionType, propSpek, inPar);
+            
+            vShapeFlag(iCell, iScan)   = vShapeFlagTmp;
+            valBICvShape(iCell, iScan) = valBICvShapeTmp;
+            valBICline(iCell, iScan)   = valBIClineTmp;
+            varOfResid(iCell, iScan) = varOfResidTmp;
+            varianceLine(iCell, iScan) = varLineTmp;
+            coefArr{iCell, iScan} = coefTmp; % TN20211025 added
+            
+        end % if scanValues(iScan) < boundMat{iCell,1}(1) || scanValues(iScan) > boundMat{iCell,1}(2)
+        
+    end % for iCell = 1:numCell
+    
+end % for iScan = 1:numThresh
+
+evalInfoBIC = {vShapeFlag, valBICvShape, valBICline};
+
+%% Get actual threshold in which variance is minimum
+[minVar,minIndx] = min(varOfResid,[],2); %minVar = value of minimum of row ith, minIndx = col index of that minimum
+threshOfMin = scanValues(minIndx); % threshOfMin = threshold that produce this minimum
+
+%% Randomize tassm (data) of each cell, shuffle observations only within groups, nRamdom of times
+for iCell = 1:numCell
+    
+    cutoffInput = [threshOfMin(iCell) divPropIndx];
+    
+    for iRand = 1:nRandom
+        
+        shuffledTassmCurr = shuffleTassmSpkl(tassm(iCell), false);
+        
+        [testResultsIndxRand, ~, testResultCutOffRand, inParRand] = ...
+            smactinAggMov(shuffledTassmCurr, matchindx(iCell),smactinFlag, ...
+            propSpek,propSM,maxNumSpklProp,1,cutoffInput, outlierParam);
+        
+        [vShapeFlagRand_tmp, valBICvShapeRand_tmp, valBIClineRand_tmp, ~, ~, coefVectRand_tmp] = ...
+            getBicAndVarResFrMvrg(testResultsIndxRand, ...
+            testResultCutOffRand, motionType, propSpek, inParRand);
+        
+        vShapeFlagRand(iCell, iRand) = vShapeFlagRand_tmp;
+        
+        % Plot randomized figure
+        if flagRandFig && iRand == 1
+            [xDat, yDat, ~] = plotFitLinesOverScatter(testResultsIndxRand, testResultCutOffRand, motionType, propSM, propSpek, maxNumSpklProp, threshOfMin(iCell));
+            ylabel('propSmRand'); xlabel('propSpekRand');
+            saveas(gcf,['scatterRandData_' figIdentifier '_' num2str(iCell) '.fig']); close all
+            randPlotData{iCell,1} = padcat(xDat, yDat, threshOfMin(iCell));
+            randPlotData{iCell,2} = coefVectRand_tmp; 
+            randPlotData{iCell,3} = cell2struct({valBICvShapeRand_tmp,valBIClineRand_tmp}, {'BIC2line', 'BIC1line'}, 2);
+        end
+        
+    end % for iRand = 1:nRandom
+    
+end % for iCell = 1:numCell
+
+vShapeNumRandOfMin = sum(vShapeFlagRand,2);
+vShapeFlagRandOfMin = vShapeNumRandOfMin > tolRand;
+
+% Sort out the rest of results at threshold where variance of residuals is minimum.
+vShapeFlagOfMin = logical.empty(numCell,0);
+edgeFlag = logical.empty(numCell,0);
+valBICvShapeOfMin = nan(numCell,1);
+valBIClineOfMin = nan(numCell,1);
+varLineOfMin = nan(numCell,1);
+coefsOfMin = cell(numCell, 1);
+
+for i = 1:numCell
+    
+    if isnan(vShapeFlag(i,minIndx(i))) % NaN cannot be assigned to logical vShapeFlagOfMin(i,1)
+        continue
+    end
+    
+    vShapeFlagOfMin(i,1) = vShapeFlag(i,minIndx(i));
+    valBICvShapeOfMin(i,1) = valBICvShape(i,minIndx(i));
+    valBIClineOfMin(i,1) = valBICline(i,minIndx(i));
+    varLineOfMin(i,1) = varianceLine(i, minIndx(i)); % I could also take any col because regression of 1-line fit is the same for every threshold, but doing this for consistency
+    
+    % ask if from index 1 to mindIndx(i) (where min threshold is), if any of
+    % the other threshold is not NaN. If any() = 0, no other threshold exist
+    % from index 1:mindIndx(i), then the current min threshold is and edge
+    % threshold. -TN 20210722
+    if minIndx(i) == 1 || minIndx(i) == size(varOfResid,2) % if the index is 1 or size(varOfResid,2), then threshold is already at the edge of scanValues
+        edgeFlag(i,1) = true;
+    else
+        startEdgeFlag = ~any(~isnan(varOfResid(i,1:minIndx(i)-1))); % 0 = not an edge threshold.
+        endEdgeFlag = ~any(~isnan(varOfResid(i,minIndx(i)+1:end))); % 0 = not an edge threshold.
+        edgeFlag(i,1) = startEdgeFlag || endEdgeFlag;
+    end
+    
+    % Regression coefficients of the 2-line & 1-line fit (TN20211025)
+    coefsOfMin{i,1} = coefArr{i,minIndx(i)};
+    
+end % for i = 1:numCell
+
+thresholdsStruct.thresholds = threshOfMin';
+thresholdsStruct.minVar = minVar;
+thresholdsStruct.vShapeFlagFinal = vShapeFlagOfMin == 1 & vShapeFlagRandOfMin == 0;
+thresholdsStruct.vShapeFlagReal = vShapeFlagOfMin;
+thresholdsStruct.vShapeFlagRand = vShapeFlagRandOfMin;
+thresholdsStruct.vShapeNumRand = vShapeNumRandOfMin;
+thresholdsStruct.valBICvShape = valBICvShapeOfMin;
+thresholdsStruct.valBICline = valBIClineOfMin;
+thresholdsStruct.edgeFlag = edgeFlag;
+thresholdsStruct.coefsOfMin = coefsOfMin;
+
+
+%% Save output table
+thresholdsTable = struct2table(thresholdsStruct);
+
+%% Add mean, median, std of "legit biphasic" as an output and save it.
+biphasicThreshArr = thresholdsTable.thresholds (thresholdsTable.vShapeFlagFinal);
+stat = [median(biphasicThreshArr), mean(biphasicThreshArr), std(biphasicThreshArr), (length(biphasicThreshArr)/numCell)];
+nonVshapeList = find(~thresholdsTable.vShapeFlagFinal); % cells that failed either criteria
+%disp(['cells that failed either criteria: ' num2str(nonVshapeList')])
+
+%% Scatter (real data) of each cell with threshold
+if flagRealFig
+    for iCell = 1:numCell
+        % plotFitLinesOverScatter(testResultsIndx{iCell}, testResultCutOff{iCell}, motionType, propSM, propSpek, maxNumSpklProp, threshOfMin(iCell));
+        plotBiphasicLines(testResultsIndx, motionType, [propSpek (propSM+maxNumSpklProp(1))], thresholdsTable, iCell, figIdentifier);
+        ylabel('propSM'); xlabel('propSpek');
+        saveas(gcf,['scatterRealData_' figIdentifier '_' num2str(iCell) '.fig']); close all
+    end
+end
+
+%% Visualize RSS and conditions
+if figureFlag
+    
+    threshOfMinVshape = threshOfMin(:,vShapeFlagOfMin);
+    threshOfMinLine = threshOfMin(:,~vShapeFlagOfMin);
+    
+    %% At all threshold, what is the improvement of 2-line fit over 1-line fit?
+    % y = dividing the variances of the 2-line fit by the variance of the the one line fit
+    f1 = figure; hold on
+    title('What is the improvement of 2-line fit over 1-line fit?')
+    xlabel('Different cut-off thresholds');
+    ylabel('Variance of residuals from 2-line fit/Variance of residuals from 1-line fit');
+    
+    yMat = varOfResid./varianceLine;
+    % Plot vShape lines in black
+    plot(scanValMat(vShapeFlagOfMin,:)', yMat(vShapeFlagOfMin,:)','k-');
+    % Plot not vShape lines in grey
+    plot(scanValMat(~vShapeFlagOfMin,:)', yMat(~vShapeFlagOfMin,:)','Color',[0.5 0.5 0.5],'LineStyle','-.');
+    
+    % Plot 'x' mark and vertical line
+    xMarkVshape = minVar(vShapeFlagOfMin,:)./varLineOfMin(vShapeFlagOfMin,:);
+    xMarkLine = minVar(~vShapeFlagOfMin,:)./varLineOfMin(~vShapeFlagOfMin,:);
+    scatter(threshOfMinVshape, xMarkVshape,'x'); scatter(threshOfMinLine, xMarkLine,'o')
+    
+    % plot vShape vertical lines in red
+    for i = 1:sum(vShapeFlagOfMin)
+        plot([threshOfMinVshape(i), threshOfMinVshape(i)], [min(f1.Children.YLim), xMarkVshape(i)], '--','Color','r')
+    end
+    % plot not vShape vertical lines in grey
+    for i = 1:sum(~vShapeFlagOfMin)
+        plot([threshOfMinLine(i), threshOfMinLine(i)], [min(f1.Children.YLim), xMarkLine(i)], '--','Color',[0.5 0.5 0.5],'LineStyle','-.');
+    end
+    saveas(f1,['2lineOver1_' figIdentifier '.fig']); close all
+    
+    %% At which threshold is variance at minimum?
+    f2 = figure; hold on
+    title('At which threshold is variance (sum(y_i - y_{mean})^2)/(n-1) at minimum?')
+    xlabel('Different cut-off thresholds');
+    ylabel('Variance of residuals from both populations (above & below)');
+    
+    % Plot vShape lines in black
+    plot(scanValMat(vShapeFlagOfMin,:)', varOfResid(vShapeFlagOfMin,:)','k-');
+    % Plot not vShape lines in grey
+    plot(scanValMat(~vShapeFlagOfMin,:)', varOfResid(~vShapeFlagOfMin,:)','Color',[0.5 0.5 0.5],'LineStyle','-.');
+    
+    xVshape = minVar(vShapeFlagOfMin,:);
+    xLine = minVar(~vShapeFlagOfMin,:);
+    scatter(threshOfMin, minVar,'x')
+    % plot vShape vertical lines in red
+    for i = 1:sum(vShapeFlagOfMin)
+        plot([threshOfMinVshape(i), threshOfMinVshape(i)], [min(f2.Children.YLim), xVshape(i)], '--','Color','r')
+    end
+    % plot not vShape vertical lines in grey
+    for i = 1:sum(~vShapeFlagOfMin)
+        plot([threshOfMinLine(i), threshOfMinLine(i)], [min(f2.Children.YLim), xLine(i)], '--','Color',[0.5 0.5 0.5],'LineStyle','-.');
+    end
+    saveas(f2,['varmin_1_' figIdentifier '.fig']); close all
+    
+    %% At which threshold is RELATIVE variance at minimum?
+    f3 = figure;
+    title('At which threshold is relative variance at minimum?')
+    hold on
+    
+    % Scale variance of the minimum variance of each cell (row) to 1 and
+    % all the other variances accordingly. (Cells are not comparable to
+    % each others, only comparable within its own different scanValues).
+    
+    % Option 0 (KJ's): divide elements of each row (each cell) by the
+    % (min(variance)) of all
+    minVarVal = min(varOfResid,[],'all');
+    scaledVar = varOfResid./minVarVal;
+    scaledMinVar = minVar./minVarVal;
+    
+    % Option 1: divide elements of each row (each cell) by the floor(min(variance)) of that row
+    if min(minVar) > 1
+        buffer = 0;
+    else
+        buffer = 1;
+    end
+    scaledVar = varOfResid./(floor(minVar) + buffer);
+    scaledMinVar = minVar./(floor(minVar) + buffer);
+    
+    % Option 2: divide elements of each row (each cell) by the min(variance) of that row
+    scaledVar = varOfResid./minVar;
+    scaledMinVar = minVar./minVar;
+    
+    % Option 3: divide elements of each row (each cell) by the first variance of that row (normalize all lines to start at the same point)
+    for i = 1:numCell
+        indxFirstVar = find(~isnan(varOfResid(i,:)),1);
+        if ~isempty(indxFirstVar)
+            firstMinVar(i,1) = varOfResid(i,indxFirstVar);
+        else
+            firstMinVar(i,1) = NaN;
+        end
+    end
+    scaledVar = varOfResid./firstMinVar;
+    scaledMinVar = minVar./firstMinVar;
+    
+    xlabel('Different cut-off thresholds');
+    ylabel('Variance of residuals from both populations (above & below)');
+    % Plot vShape lines in black
+    plot(scanValMat(vShapeFlagOfMin,:)', scaledVar(vShapeFlagOfMin,:)');%,'k-');
+    % Plot not vShape lines in grey
+    plot(scanValMat(~vShapeFlagOfMin,:)', scaledVar(~vShapeFlagOfMin,:)','Color',[0.5 0.5 0.5],'LineStyle','-.');
+    
+    scaledMinVarV = scaledMinVar(vShapeFlagOfMin,:);
+    scaledMinVarL = scaledMinVar(~vShapeFlagOfMin,:);
+    scatter(threshOfMin, scaledMinVar ,'x')
+    
+    % Plot vShape vertical lines in red
+    for i = 1:sum(vShapeFlagOfMin)
+        plot([threshOfMinVshape(i), threshOfMinVshape(i)], [0, scaledMinVarV(i)], '--','Color','r')
+    end
+    % Plot not vShape vertical lines in grey
+    for i = 1:sum(~vShapeFlagOfMin)
+        plot([threshOfMinLine(i), threshOfMinLine(i)], [0, scaledMinVarL(i)], '--','Color',[0.5 0.5 0.5],'LineStyle','-.');
+    end
+    
+    saveas(f3,['varmin_2_' figIdentifier '.fig']); close all
+    
+end % (if figureFlag)
+
+end
+
+%% Sub-functions
+function [residualsDat, rss, variance, variance2, variance3, variance4, variance5, variance6] = ...
+    getRssFromMvrg(testResultMvrgStruct)
+% GETRSSFROMMVRG: takes a structure of mvrg (output of mvregress from
+% smactinAggMov.m) and calculate variance of residues
+% Calculating variance of residues by
+% (1) RSS/n			     (4) sum(yi – ymean)/n
+% (2) RSS/(n-1)		 	 (5) sum(yi – ymean)/(n-1)
+% (3) RSS/(n-2)			 (6) sum(yi – ymean)/(n-2)
+% Remark: the residualsDat extracted .residuals field, including any NaNs.
+if ~isstruct(testResultMvrgStruct) || isfield(testResultMvrgStruct,'nanFlag')
+    residualsDat = [];
+    rss = NaN;
+    variance = NaN;
+    variance2 = NaN;
+    variance3 = NaN;
+    variance4 = NaN;
+    variance5 = NaN;
+    variance6 = NaN;
+    
+else
+    if size(testResultMvrgStruct.residuals,2) == 1
+        residualsDat = testResultMvrgStruct.residuals(:,:);
+    elseif size(testResultMvrgStruct.residuals,2) == 3 || size(testResultMvrgStruct.residuals,2) == 4
+        residualsDat = testResultMvrgStruct.residuals(:,2); % hard-coded column 2 because biphasic behavior is observed in y = SM diff coef (which is col = 2 in mvrg.residuals)
+    else
+        warning('Function is not built to handle this number of sm properties.')
+    end
+    [rss, variance, variance2, variance3, variance4, variance5, variance6] = ...
+        getVarianceFromResiduals(residualsDat);
+end
+
+% if ~isstruct(testResultCutOff{iCell, 1}{2, 1}.mvrgs{1, motionType+1}) || ...
+%         isfield(testResultCutOff{iCell, 1}{2, 1}.mvrgs{1, motionType+1},'nanFlag')
+%     rssAbove(iCell,iScan) = NaN;
+%     varianceAbv(iCell,iScan) = NaN;
+%     varianceAbv2(iCell,iScan) = NaN;
+%     residualsAbv = [];
+% else
+%     residualsAbv = testResultCutOff{iCell, 1}{2, 1}.mvrgs{1, motionType+1}.residuals(:,2);
+%     rssAbove(iCell,iScan) = nansum(residualsAbv.^2);
+%     varianceAbv(iCell,iScan) = nansum((residualsAbv-nanmean(residualsAbv)).^2)/size(residualsAbv,1);
+%     varianceAbv2(iCell,iScan) = rssAbove(iCell,iScan)/size(residualsAbv,1);
+%
+% end
+%
+%
+% if ~isstruct(testResultCutOff{iCell, 1}{2, 2}.mvrgs{1, motionType+1})|| ...
+%         isfield(testResultCutOff{iCell, 1}{2, 2}.mvrgs{1, motionType+1},'nanFlag')
+%     rssBelow(iCell,iScan) = NaN;
+%     varianceBel(iCell,iScan) = NaN;
+%     varianceBel2(iCell,iScan) = NaN;
+%     residualsBel = [];
+% else
+%     residualsBel = testResultCutOff{iCell, 1}{2, 2}.mvrgs{1, motionType+1}.residuals(:,2);
+%     rssBelow(iCell,iScan) = nansum(residualsBel.^2);
+%     varianceBel(iCell,iScan) = nansum((residualsBel-nanmean(residualsBel)).^2)/size(residualsBel,1);
+%     varianceBel2(iCell,iScan) = rssBelow(iCell,iScan)/size(residualsBel,1);
+% end
+end
+
+function [rss, variance, variance2, variance3, variance4, variance5, variance6] = getVarianceFromResiduals(residuals)
+% Calculating variance of residues by
+% (1) RSS/n			     (4) sum(yi – ymean)/n
+% (2) RSS/(n-1)		 	 (5) sum(yi – ymean)/(n-1)
+% (3) RSS/(n-2)			 (6) sum(yi – ymean)/(n-2)
+if isempty(residuals)
+    rss = NaN;
+    variance  = NaN;
+    variance2 = NaN;
+    variance3 = NaN;
+    variance4 = NaN;
+    variance5 = NaN;
+    variance6 = NaN;
+else
+    rss = nansum(residuals.^2);
+    n = size(residuals(~isnan(residuals)),1);
+    resMean = nanmean(residuals);
+    % (1) RSS/n
+    variance = rss/n;
+    % (2) RSS/(n-1)
+    variance2 = rss/(n-1);
+    % (3) RSS/(n-2)
+    variance3 = rss/(n-2);
+    % (4) sum(yi – ymean)/n
+    variance4 = nansum((residuals-resMean).^2)/n;
+    % (5) sum(yi – ymean)/(n-1) (calculate resMean from data points so 1 less degree of freedom)
+    variance5 = nansum((residuals-resMean).^2)/(n-1);
+    %variance52 = var(residuals,'omitnan');
+    % (6) sum(yi – ymean)/(n-2)
+    variance6 = nansum((residuals-resMean).^2)/(n-2);
+end
+end
+
+function [vShapeInvertFlag, coef1, coef2] = checkInvtVshapeCoef(testResultCutOffCell, motionType, inPar)
+% check invert vShape: below threshold fit slope is positive, above
+% threshold fit slope is negative.
+
+if inPar{6} % inputParam{6} = mvrgAggMatFlag (if = 1, then aggMat was used for MVRG, not normalized aggMat)
+    coef2 = testResultCutOffCell{2, 1}.mvrgs{1, motionType+1}.coef(2); % coef of above population
+    coef1 = testResultCutOffCell{2, 2}.mvrgs{1, motionType+1}.coef(2); % coef of below population
+else
+    error('Function not written with running normAggMat in mind.')
+end
+
+
+if coef1 > 0 && coef2 < 0
+    vShapeInvertFlag = true;
+else
+    vShapeInvertFlag = false;
+end
+
+end
+
+function [vShapeFlag, valBICvShape, valBICline, varOfResid, variance1Line, coefVect] = getBicAndVarResFrMvrg(testResultsIndxCell, testResultCutOffCell, motionType, propSpek, inParam)
+%GETBICANDVARRESFRMVRG:  take results of MVRG (testResultsInd &
+%testResultCutOff) and returns information regarding BIC assessment of 1
+%line fit vs vShape fit and variance of residuals from vShape fit.
+%OUTPUT: coefVect = (1x2 vector), coefVect(1) = coef of regression on below
+%population, coefVect(2) = coef of regression on above population
+%% Check requirement:
+% % min = 11 datapoints per MVRG
+% All datapoints (1 line case): Make sure that MVRG ran
+mvrgAllFlag = isstruct(testResultsIndxCell{2,1}.mvrgs{1,motionType+1}) && ...
+    ~isfield(testResultsIndxCell{2,1}.mvrgs{1,motionType+1},'nanFlag');
+
+% Above threshold (2 lines case)
+complIndxAbv = testResultCutOffCell{2,1}.completeFlag{1,motionType+1};
+inlrIndxAbv = testResultCutOffCell{2,1}.outlierFlag{1,motionType+1};
+aggMatComplAbv = testResultCutOffCell{2,1}.aggMat{1,motionType+1}(complIndxAbv,:);
+aggMatComplInlrAbv = aggMatComplAbv(inlrIndxAbv,:);
+% Below threshold (2 lines case)
+complIndxBel = testResultCutOffCell{2,2}.completeFlag{1,motionType+1};
+inlrIndxBel = testResultCutOffCell{2,2}.outlierFlag{1,motionType+1};
+aggMatComplBel = testResultCutOffCell{2,2}.aggMat{1,motionType+1}(complIndxBel,:);
+aggMatComplInlrBel = aggMatComplBel(inlrIndxBel,:);
+
+insuffDatFlag = min([size(aggMatComplInlrAbv,1),size(aggMatComplInlrBel,1)]) < 11;
+
+% % Make sure that both Below & Above group has MVRG ran
+mvrgAbvFlag = isstruct(testResultCutOffCell{2,1}.mvrgs{1,motionType+1}) && ...
+    ~isfield(testResultCutOffCell{2,1}.mvrgs{1,motionType+1},'nanFlag');
+mvrgBelFlag = isstruct(testResultCutOffCell{2,2}.mvrgs{1,motionType+1}) && ...
+    ~isfield(testResultCutOffCell{2,2}.mvrgs{1,motionType+1},'nanFlag');
+
+if insuffDatFlag || ~mvrgAbvFlag || ~mvrgBelFlag
+    flagBIC = false;
+else
+    flagBIC = true;
+end
+
+%% Get variance of residuals of "all" (1-line fit)
+if mvrgAllFlag
+    residuals1Line = getRssFromMvrg(testResultsIndxCell{2,1}.mvrgs{1, motionType+1});
+    [~, ~, ~, ~, ~, variance1Line] = getVarianceFromResiduals(residuals1Line);
+else
+    variance1Line = NaN;
+end
+
+
+if flagBIC
+    %% Get variance of residuals for each threshold (2-line fit)
+    % Each population
+    residualsAbv = getRssFromMvrg(testResultCutOffCell{2, 1}.mvrgs{1, motionType+1});
+    residualsBel = getRssFromMvrg(testResultCutOffCell{2, 2}.mvrgs{1, motionType+1});
+    
+    residualsAll  = vertcat(residualsAbv , residualsBel ); % Both population
+    
+    % Get variance
+    [~, ~, ~, ~, ~, varOfResid] = getVarianceFromResiduals(residualsAll);
+    
+    %% BIC: (simple formula based on variance (& number of available datapoints) & number of parameters)
+    % Discussed: number of parameters (1 line fit => 1 parameters, 2 line fits => either 2 or 3 parameters???))
+    % v-shape
+    numDataPtsVshape = length(residualsAll );
+    residualsVshape = residualsAll ; %residualsAll
+    numParamVshape = 2*(length(propSpek) + 1); % 2 lines (unnormalized data), each has 1 slope & 1 intercept in default case
+    valueVshapeBIC = numDataPtsVshape*log(sum(residualsVshape.^2)/numDataPtsVshape) + log(numDataPtsVshape)*numParamVshape;
+    
+    % line:
+    numDataPtsLine = sum(testResultsIndxCell{2, 1}.outlierFlag{1, motionType+1});
+    residualsLine = getRssFromMvrg(testResultsIndxCell{2, 1}.mvrgs{1, motionType+1});
+    numParamLine = length(propSpek) + 1; % 1 line, has 1 slopes & 1 intercept in default case
+    valueLineBIC = numDataPtsLine*log(sum(residualsLine.^2)/numDataPtsLine) + log(numDataPtsLine)*numParamLine; % line has slope & intercept
+    
+    % vshape flag
+    twoLineFlag  = valueVshapeBIC < valueLineBIC; % 1 if data is better described with 2-line model (v-shape)
+    vShapeInvertFlag = checkInvtVshapeCoef(testResultCutOffCell, motionType, inParam); % 1 if data transition from positive slope to negative slope when value of x (speckle prop) is increased
+    vShapeFlag  = twoLineFlag & vShapeInvertFlag; % 1 if data is better described with 2-line model (v-shape), 0 if data is better described with 1-line model or if 2 lines are not vShape
+    valBICvShape  = valueVshapeBIC;
+    valBICline  = valueLineBIC;
+    
+    %% Get coefficients and slope of fit line
+    coef1line = testResultsIndxCell{2,1}.mvrgs{1,motionType+1}.coef; % coef1line(1) is intercept, coef1line(2) is slope
+    coefAbove = testResultCutOffCell{2, 1}.mvrgs{1, motionType+1}.coef; % coefAbove(1) is intercept, coefAbove(2) is slope
+    coefBelow = testResultCutOffCell{2, 2}.mvrgs{1, motionType+1}.coef; % coefBelow(1) is intercept, coefBelow(2) is slope
+    coefVect = horzcat(coefBelow, coefAbove, coef1line); % row 1 are intercepts, row 2 are slopes
+    
+else % if number of datapoint criteria does not pass, then cell is not biphasic.
+    vShapeFlag  = false;
+    valBICvShape  = NaN;
+    valBICline  = NaN;
+    varOfResid  = NaN;
+    coefVect = NaN;
+end
+clear flagBIC
+end
+
+function [xDat, yDat, coefsOfMin] = plotFitLinesOverScatter(testResultsInd, testResultCutOff, motionType, propSM, propSpek, maxNumSpklProp, thres)
+% thres = thresholdsTable.thresholds(1);
+
+% Data:
+mvrgCell1_Above_atMinThresh = testResultCutOff{2, 1}.mvrgs{1, motionType+1};
+mvrgCell1_Below_atMinThresh = testResultCutOff{2, 2}.mvrgs{1, motionType+1};
+mvrgCell1All_atMinThresh = testResultsInd{2, 1}.mvrgs{1, motionType+1};
+
+if isfield(mvrgCell1_Above_atMinThresh,'nanFlag') || isfield(mvrgCell1_Below_atMinThresh,'nanFlag') || isfield(mvrgCell1All_atMinThresh,'nanFlag')
+    xDat = NaN; yDat = NaN;
+    coefsOfMin = [];
+    return
+else
+    yDat= testResultsInd{2,1}.aggMat{1,motionType+1}(:,propSM+maxNumSpklProp(1));
+    xDat = testResultsInd{2,1}.aggMat{1,motionType+1}(:,propSpek);
+    
+    
+    figure; scatter(xDat,yDat); hold on
+    
+    x = min(xDat):(max(xDat)-min(xDat))/100:max(xDat);
+    x2lineBelow = min(xDat):(thres-min(xDat))/100:thres;
+    x2lineAbove = thres:(max(xDat)-thres)/100:max(xDat);
+    
+    y1line = mvrgCell1All_atMinThresh.coef(1) + mvrgCell1All_atMinThresh.coef(2)*x;
+    
+    plot(x,y1line,'k') % threshold
+    
+    yBelow = mvrgCell1_Below_atMinThresh.coef(1) + mvrgCell1_Below_atMinThresh.coef(2)*x2lineBelow;
+    plot(x2lineBelow,yBelow,'r')
+    
+    yAbove = mvrgCell1_Above_atMinThresh.coef(1) + mvrgCell1_Above_atMinThresh.coef(2)*x2lineAbove;
+    plot(x2lineAbove,yAbove,'r')
+    xline(thres,'--r')
+    
+    % Output MVRG lines
+    coefsOfMin = nan(2,3);
+    coefsOfMin(1,1) = mvrgCell1_Below_atMinThresh.coef(1); % below, y-intercept
+    coefsOfMin(2,1) = mvrgCell1_Below_atMinThresh.coef(2); % below, slope
+    coefsOfMin(1,2) = mvrgCell1_Above_atMinThresh.coef(1); % above, y-intercept
+    coefsOfMin(2,2) = mvrgCell1_Above_atMinThresh.coef(2); % above, slope
+    coefsOfMin(1,3) = mvrgCell1All_atMinThresh.coef(1); % all, y-intercept
+    coefsOfMin(2,3) = mvrgCell1All_atMinThresh.coef(2); % all, slope
+
+end % isfield
+
+end

--- a/smPropPerTimeInterval.m
+++ b/smPropPerTimeInterval.m
@@ -1,0 +1,824 @@
+function [smPropPerTimeInt,threshMet, summaryNumTrackAll, numPassDecomptrackAll, intensityModelInfoPerMov] = ...
+    smPropPerTimeInterval(utrackPackPaths, smConditions,qfsmPackPaths, ...
+    diffModeDividerStruct, smSpanRadius, intensityInfoBackUp)
+%SMPROPPERTIMEINTERVAL reads data from u-track analysis folders and calculates spatiotemporal properties of single-molecule data
+%
+%SYNOPSIS: [smPropPerTimeInt,threshMet, summaryNumTrackAll, numPassDecomptrackAll, intensityModelInfoPerMov] = smPropPerTimeInterval(utrackPackPaths, smConditions, qfsmPackPaths, diffModeDividerStruct, smSpanRadius, intensityInfoBackUp)
+%
+%INPUT:  utrackPackPaths: (n x 1 cell) paths leading to n U-Track analysis
+%                         results in "TrackingPackage" folders.
+%
+%           smConditions: (structure) parameters for processing tracks;
+%                         contains the following fields.
+%
+%                       .minLft: (n x 1 vector of integer) minimum acceptable
+%                                lifetime for single-molecules for motion
+%                                analysis. Any SM with lifetime lower than
+%                                the minLft will be eliminated from processing.
+%                                Recommended value: 10
+%
+%                       .rad_density: (n x 1 vector of double) radius used
+%                                for calculating local SM density.
+%                                Recommended value: 7 (empirically determined by Deryl T. 2018)
+%
+%                       .windAvg: (n x 1 vector of integer) number of SMI frames
+%                                 used to average (split) SMI data into FSM intervals.
+%
+%                       .divFlag: (n x 1 vector of integer) flags
+%                                 indicating how SMI frames are matched
+%                                 temporally to FSM frames.
+%                          = -1 : link SM frames to earlier FSM frames
+%                          =  0 : link SM frames to center FSM frames
+%                          =  1 : link SM frames to later FSM frames
+%
+%                       .maskLoc: (n x 1 vector of integer) flag indicating
+%                                location of cell ROI mask.
+%                                See getActinMask.m for details.
+%                          = 0 : there exists 1 mask in local SMI folder
+%                                called "ImportedCellMask".
+%                          = 1 : (MANUAL) there exists a folder with external
+%                                masks within path provided in
+%                                qfsmPackPaths (make sure folder name
+%                                follows a name in extlroi variable.)
+%                          = 2 : (AUTOMATED) there exists a folder with refined
+%                                masks within the QFSMPackage folder
+%                                provided in qfsmPackPaths
+%                          = 3 : there exists a folder with refined
+%                                masks within the SegmentationPackage
+%                                folder provided in qfsmPackPaths
+%                          if .maskLoc = [], the code will crash.
+%
+%                       .randFlag: flag to indicate randomization of SM tracks
+%                                  (i.e., moving SM tracks from its
+%                                  original location to somewhere else on
+%                                  the eroded mask)
+%                           = 1: randomize track position to any location
+%                                in mask ROI
+%
+%                       .clean : (n x 1 vector of logical) flag indicating
+%                                whether SM tracks from u-track has been
+%                                cleaned (artifacts removed).
+%                         = true. Default: Function will look for
+%                                cleaned_Channel_1_tracking_result.mat 
+%                                Error will be output if such file is not found
+%                         = false. Function will look for
+%                                Channel_1_tracking_result.mat
+%
+%          qfsmPackPaths: (n x 1 cell) paths leading to QFSM Package
+%                          results. This is for loading masks.
+%
+%           smSpanRadius: (integer) radius of domain that a single sm can
+%                         span before being chopped into (multiple)
+%                         spatially localized tracklets, with equal lifetimes.
+%                         Optional. Default = 300/9
+%
+%  diffModeDividerStruct: (structure -- input not implemented) parameters
+%                         for performing diffusion mode analysis; contains
+%                         the following fields:
+%                      .trajLength: Trajectory lengths for which mode divider values
+%                        are supplied.
+%                      .coordStd  : Coordinate standard deviations for which mode
+%                        divider values are supplied.
+%                      .divider   : (number of trajectory lengths) x (number of
+%                        coordinates stds) x (number of modes - 1) array
+%                        of mode divider values.
+%                       Optional. Input not implemeted. Default = [].
+%
+%           intensityInfoBackUp: (optional) data of monomer intensity as
+%                         [dataMean dataStdev], used to estimate oligomeric
+%                         state if automatic estimation at each movie error
+%                         out. This option should only only be used to test
+%                         movie with only 1 track, which did not contain
+%                         enough info for estimating monomer intensities. 
+%                       Either: row vector of 2 values
+%                       Or    : cell array for n movies, each cell is the
+%                               param for each movie
+%
+%OUTPUT:   smPropPerTimeInt: (n x 1 cell array of structures) SMI arm
+%                            analysis results of SMI-FSM analysis for n
+%                            movies; contains various properties of SM;
+%                            each structure contains the following fields:
+%
+%                   .smFrames        : List of SM frames associated with each FSM frame.
+%
+%                   .smList          : List of SM tracks that exist in each FSM interval.
+%
+%                   .meanPos         : Mean position (x/y-coordinates) per SM track each FSM interval.
+%
+%                   .meanDisp        : Mean frame-to-frame displacement per SM track each FSM interval.
+%
+%                   .lifetime        : final frame of the last observation for a SM track
+%                                  minus the first frame of the first observation for
+%                                  a SM track within a particular FSM interval.
+%
+%                   .numObservations : number of observations for a SM track within a FSM interval.
+%
+%                   .netVelocity     : SM velocity vector  per frame averaged
+%                                  across each FSM interval.
+%
+%                   .meanAmp         : mean intensity of a SM track during an FSM interval.
+%
+%                   .netSpeed        : the net speed for a particular SM track during an FSM interval.
+%
+%                   .netVelAngle     : the net velocity angle within an FSM interval.
+%                                  For a SM track, this is the angle between .netSpeed
+%                                  direction and a horizontal axis crossing the initial
+%                                  position of the SM track.
+%
+%                   .trackClass      : classification of all tracks based on moment
+%                                  scaling spectrum analysis.
+%                                   = 0 : immobile
+%                                   = 1 : confined brownian
+%                                   = 2 : pure brownian (free diffusion)
+%                                   = 3 : directed motion
+%
+%                   .diffCoef        : diffusion coefficient of each SM track in an FSM interval;
+%                                  row corresponding to SM index.
+%
+%                   .confRad         : max pairwise distance of localizations
+%                                  row corresponds to SM index.
+%
+%                   .diffMode        : SM diffusion mode type as analysed by diffusionModeAnalysis
+%
+%                   .diffCoefF2F     : SM diffusion coefficient calculated from frame-to-frame displacement
+%
+%                   .diffRad         : SM diffusion radius from diffusionModeAnalysis (not implemented TN20210310)
+%
+%                   .mssSlope        : SM mssSlope from trackDiffusionAnalysis1 (added TN Dec 2022/Jan 2023)
+%
+%                   .meanSmDensity   : mean local SM density per FSM interval
+%
+%                   .smFramesExist   : frames at which this SM's localization exist.
+%
+%                   .f2fAmp          : frame-to-frame amplitude.
+%
+%                   .mergeInfoSpace  : xy-location of merge events.
+%
+%                   .splitInfoSpace  : xy-location of split events.
+%
+%                   .mDiffMode       : (calculated by mode analysis) Diffusion mode
+%
+%                   .mDiffCoef       : (calculated by mode analysis)
+%                                       Diffusion coefficient from mean
+%                                       square F2F displacement  
+%
+%                   .mMsdF2F         : (calculated by mode analysis) Mean
+%                                       square F2F displacement. 
+%
+%                   .mMeanPosStd     : (calculated by mode analysis) Mean
+%                                       positonal standard deviation. 
+% 
+%                   .mDiffRadius     : (calculated by mode analysis)
+%                                       Diffusion radius. 
+%                                      (confinement radius of immobile & confined SM track)
+%
+%                   .mLifetime       : (calculated by mode analysis) Track
+%                                       lifetime. Identical to .lifetime
+%
+%               threshMet  : (n x 1 cell vectors) contains SM indices that exists within
+%                             cell ROI masks from qFSM.
+%
+%               summaryNumTrackAll: (table of n*m rows) summary of the number of
+%                                   tracklets added by each SM track processing
+%                                   steps for m FSM intervals of n movies;
+%                                   contains the following columns:
+%                                           iMov
+%                                           iFrame (indicates the FSM interval)
+%                                           numTrack
+%                                           trackWithTransMot
+%                                           totTransMotTracklet
+%                                           addedByDcmss
+%                                           numTrackDcmss
+%                                           addedByTime
+%                                           numAfterTime
+%                                           addedBySpan
+%                                           numAfterSpan
+%                                           numBigSpan
+%
+%            numPassDecomptrackAll: (table of n*m rows) summary of number
+%                                   of tracks from u-track that is split by
+%                                   each FSM interval; contains the
+%                                   following columns
+%                                           iMov
+%                                           sizeMinDecompTrack
+%                                           numPassTrack
+%
+%           intensityModelInfoPerMov: structure containing information for
+%                                   intensity model fitting parameters
+%                                   estimated from each movie.
+%
+%GLOSSARY:  SM  : single molecule
+%           SMI : sinlge molecule imaging
+%           QFSM: quantitative Fluorescent Speckle Microscopy
+%           FL  : full-length (refer to compTrack pre-chopping)
+%
+% Deryl Tschoerner, February 2018
+% Modified by Khuloud Jaqaman, February 2019
+% Extensively modified by Tra H. Ngo, September 2019
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Input control, Output initializations & definitions:
+if isempty(utrackPackPaths)
+    error('error:: single-particle tracking path was not found')
+elseif isempty(qfsmPackPaths) && sum(smConditions.maskLoc) > 0
+    error('error:: speckle information path was not found')
+end
+
+numMovs = length(utrackPackPaths); % number of SM movies being processed
+numFramesFSM = nan(numMovs,1); % number of FSM speckle frame
+numFramesSM  = nan(numMovs,1); % number of SM frame
+smPropPerTimeInt = cell(numMovs,1); % cell array containing SM properties
+threshMet        = cell(numMovs,1); % cell array containing SM indices within mask
+summaryNumTrackAll = []; % initialize table of track summary statistics
+numPassDecomptrackAll = [];  % initialize table of track summary statistics
+
+if ~exist('diffModeDividerStruct','var')
+    diffModeDividerStruct = []; 
+end
+
+if ~exist('smSpanRadius','var')|| isempty(smSpanRadius)
+    smSpanRadius = 300/9; % (pixels ~ 3um for pixel size = 90nm)
+    warning('Span radius defaults to 33.33 pixels.')
+end
+
+if ~exist('intensityInfoBackUp','var') || isempty(intensityInfoBackUp)
+    % Only use when movie is composed of a few frames. Used for bug testing
+    intensityInfoBackUp = [0.0014,0.0004]; % some value from an arbitrary CD36 movie
+end
+
+if ~isfield(smConditions,'max2TracksSize'), smConditions.max2TracksSize = 40; end
+if ~isfield(smConditions,'clean'), smConditions.clean = true(numMovs,1); end
+
+intensityModelInfoPerMov = struct('variableMean', [], 'modeParam', [], 'intensityInfo', []);
+    
+%% Looping through each sm movie
+for iMov = 1 : numMovs
+    
+    % if one of the paths are empty, move on to the next listed path
+    if isempty(utrackPackPaths{iMov,1}), continue; end
+    
+    % define smPropPerTimeInt output: each cell contains SM properties calculated for each movie
+    smPropPerTimeInt{iMov,1} = struct;
+    
+    %% load relevant mask information:    
+    masksDirOut = getSmMask(utrackPackPaths, smConditions.maskLoc, qfsmPackPaths, iMov);
+    
+    %% load uTrack output "tracksFinal" in "TrackingPackage/tracks" folder:
+    try
+        if smConditions.clean(iMov)
+            load([utrackPackPaths{iMov,1} filesep 'tracks' filesep ...
+                'cleaned_Channel_1_tracking_result.mat'], 'tracksFinal');
+        else
+            load([utrackPackPaths{iMov,1} filesep 'tracks' filesep ...
+                'Channel_1_tracking_result.mat'], 'tracksFinal');
+        end
+    catch
+        error('tracksFinal DOES NOT LOAD! When smConditions.clean is not 0, function expects cleaned_Channel_1_tracking_result.mat.')
+    end
+    
+    %% Eliminating obviously useless data
+    criteria.lifeTime.min = smConditions.minLft(iMov);
+    indxKeep = chooseTracks(tracksFinal,criteria);
+    tracksFinal = tracksFinal(indxKeep);
+    
+    %% Calculate full-length (FL) SM data size
+    %KJ 20210714: get number of SM frames from sequence of events
+    seqOfEvents = vertcat(tracksFinal.seqOfEvents);
+    numFramesSM(iMov) = max(seqOfEvents(:,1));
+    
+    % calculate relevant interval between FSM and SM movies based on smConditions input
+    numFramesFSM(iMov) = floor(numFramesSM(iMov) / smConditions.windAvg(iMov) + 1);
+    
+    %% Time frame assignment:: getting .smFrames
+    
+    % assigning which SM frame(s) belong to each FSM frame and which particle(s)
+    % belong to which interval of frames - depending on divFlag input
+    
+    switch smConditions.divFlag(iMov)
+        
+        case 0
+            
+            %to divide an interval for centering FSM frame
+            cHalf = ceil(smConditions.windAvg(iMov) / 2);
+            
+            %the first interval will begin with the first FSM frame
+            windFirst = 1;
+            
+            %one more interval for centered
+            windAdd = 1;
+            
+            %all intervals but first
+            for iFr = numFramesFSM(iMov) : -1 : 2
+                smPropPerTimeInt{iMov,1}(iFr,1).smFrames = ...
+                    ((iFr - 2)*smConditions.windAvg(iMov) + cHalf + 1: (iFr - 1)*smConditions.windAvg(iMov) + cHalf + 1)';
+            end
+            
+            %first interval
+            smPropPerTimeInt{iMov,1}(1,1).smFrames = (1 : cHalf + 1)';
+            
+            %last interval
+            indxKeep = find(smPropPerTimeInt{iMov,1}(numFramesFSM(iMov),1).smFrames <= numFramesSM(iMov));
+            smPropPerTimeInt{iMov,1}(numFramesFSM(iMov),1).smFrames = smPropPerTimeInt{iMov,1}(numFramesFSM(iMov),1).smFrames(indxKeep); %#ok<FNDSB>
+            
+            
+        case -1
+            
+            %no interval increment if not centered
+            windAdd = 0;
+            
+            %the first interval will begin with the first FSM frame
+            windFirst = 1;
+            
+            %memory allocation for frame intervals via assignment of last
+            %interval
+            lastFrameSM = min( (numFramesFSM(iMov)-1)*smConditions.windAvg(iMov)+1 , numFramesSM(iMov) );
+            smPropPerTimeInt{iMov,1}(windFirst + (numFramesFSM(iMov) - 2),1).smFrames = ...
+                ((numFramesFSM(iMov) - 2)*smConditions.windAvg(iMov) + 1 : lastFrameSM)';
+            
+            %assigning all other intervals
+            for iFr = windFirst : windFirst + (numFramesFSM(iMov) - 3)
+                smPropPerTimeInt{iMov,1}(iFr,1).smFrames = ...
+                    ((iFr - windFirst)*smConditions.windAvg(iMov) + 1 : ...
+                    (iFr + 1 - windFirst)*smConditions.windAvg(iMov) + 1)';
+            end
+            
+        case 1
+            
+            %no interval increment if not centered
+            windAdd = 0;
+            
+            %the first interval will begin with the second FSM frame
+            windFirst = 2;
+            
+            %memory allocation for frame intervals via assignment of last
+            %interval
+            lastFrameSM = min( (numFramesFSM(iMov)-1)*smConditions.windAvg(iMov)+1 , numFramesSM(iMov) );
+            smPropPerTimeInt{iMov,1}(windFirst + (numFramesFSM(iMov) - 2),1).smFrames = ...
+                ((numFramesFSM(iMov) - 2)*smConditions.windAvg(iMov) + 1 : lastFrameSM)';
+            
+            %assigning all other intervals
+            for iFr = windFirst : windFirst + (numFramesFSM(iMov) - 3)
+                smPropPerTimeInt{iMov,1}(iFr,1).smFrames = ...
+                    ((iFr - windFirst)*smConditions.windAvg(iMov) + 1 : ...
+                    (iFr + 1 - windFirst)*smConditions.windAvg(iMov) + 1)';
+            end
+            
+    end
+    
+    %% Clean up tracks
+    [tracksReform,~] = removeSimultaneousMergeSplit(tracksFinal);
+    [tracksReformat] = reformatSplitsMergesKeepLongerLivedSegment(tracksReform);
+    thresholdTime = [];
+    tracksClean = removeSplitMergeArtifactsChronological(tracksReformat,thresholdTime); % use default for 2nd input
+    
+    %% Assign clustering/oligomerization/assembly state
+    
+    try
+        
+        % Get intensity information (Monomer intensity mean & stdev) for each movie
+        tmpTrackSEL = getTrackSEL(tracksClean);
+        tmpRealStart = min(tmpTrackSEL (:,1)); % get earliest track start
+        intensityFitEndFr = tmpRealStart + 9;
+        intensityFitBegFr = tmpRealStart + 5;
+        observations = getIntensityByFrameFromTrack(tracksClean, intensityFitEndFr, intensityFitBegFr); % collect observations (vector of intensity from frame range of tracksFinal)
+        
+        alpha = 1; % (use BIC instead of F-test)
+        variableMean = -2;
+        variableStd = 3; % by Mutch et al. Biophys 2007 (mean and standard deviation of mode n were ~ n times those of mode 1)
+        showPlot = 0;
+        numModeMinMax = 4; % empirically decided; (most CD36 fits don't even get to tetramer, increasing the maximum number of possible fitted mode doesn't change the fit result)
+        binStrategy = 2; % default
+        plotName = 'Figure';
+        logData = 1; % log-normal fit (instead of Gaussian fit)
+        modeParamIn = []; % default
+        ratioTol = 0.1; % (empirically determined after looking at CD36 & VEGFR2 results)
+        
+        [~,~,modeParam,~,~] = ...
+            fitHistWithGaussians(observations,alpha,variableMean,variableStd,...
+            showPlot,numModeMinMax,binStrategy,plotName,logData,modeParamIn,ratioTol);
+        
+        if size(modeParam,1) > 1 % take mode 2 as the reference (mode 1 = 2nd mode's intensity divided by 2)
+            
+            param = modeParam(2,1:2); % log normal distribution parameters of mode 2
+            dataMean = exp(param(1)+param(2)^2/2); % convert to data parameters
+            %dataVar = exp(param(2)^2+2*param(1))*(exp(param(2)^2)-1);
+            
+            paramMode1 = modeParam(1,1:2);
+            dataVarMode1 = exp(paramMode1(2)^2+2*paramMode1(1))*(exp(paramMode1(2)^2)-1);
+            dataStdev1 = sqrt(dataVarMode1);
+            
+            intensityInfo = [dataMean/2 dataStdev1];
+            % mean intensity of mode 1 = mean intensity of mode 2 / 2
+            % we are taking the variance of mode 1 as fitted, because right now
+            % this input is inconsequent for aggregStateFromCompTracksMIQP.
+            
+        else % Exception handling if the fit only has Mode 1
+            
+            param = modeParam(1,1:2); % log normal distribution parameters of mode 1
+            dataMean = exp(param(1)+param(2)^2/2); % convert to data parameters
+            dataVar = exp(param(2)^2+2*param(1))*(exp(param(2)^2)-1);
+            dataStdev = sqrt(dataVar);
+            
+            intensityInfo = [dataMean dataStdev]; % monomer's mean
+        end
+        
+    catch
+        if iscell(intensityInfoBackUp) % TN20240501 add intensityFitParam as output 
+            intensityInfo = intensityInfoBackUp{iMov};
+        else
+            intensityInfo = intensityInfoBackUp;
+        end
+        warning('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+        warning('Intensity analysis error. Using back-up intensity information.')
+        warning('This should only be allowed if user do not care about intensity information')
+        warning('This should only be allowed if there is only 1 compound track from u-track.')
+        warning('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+    end
+    
+    try intensityModelInfoPerMov.variableMean{iMov,1} = variableMean; catch, end
+    try intensityModelInfoPerMov.modeParam{iMov,1} = modeParam; catch, end
+    intensityModelInfoPerMov.intensityInfo{iMov,1} = intensityInfo;
+    
+    % Get compTrack with oligomeric states
+    [compTracksOut] = aggregStateFromCompTracksMIQP(tracksClean,intensityInfo);
+    compTrackAltAgg = compTracksOut.alternativeFormatTracks;
+    clear tracksClean
+    
+    %% Get merge & split information:
+    try % if there are split or merge events, collect them - added TN20230802
+        [mergesInfo,splitsInfo,mergesInfoSpace,splitsInfoSpace] = ...
+            findMergesSplits(compTracksOut.defaultFormatTracks, 2, 0, 0, 0);
+    catch
+        mergesInfo = []; splitsInfo = []; mergesInfoSpace = []; splitsInfoSpace = [];
+    end
+    
+    %% Decompounded-tracks
+    [decompTrack] = decompoundCompTracks(compTrackAltAgg);
+    
+    % Count number of tracks that will get split by FSM intervals
+    try
+        tmpSmFr = [smPropPerTimeInt{iMov,1}.smFrames]; % matrix of all SMI frames, col = FSM intervals
+        fsmSplitFrs = tmpSmFr(end,1:end-1);
+    catch
+        fsmSplitFrs = [51   101   151   201   251   301   351   401   451   501   551   601   651   701   751   801   851];
+    end
+    [~, numPassTrack] = selTrackChecker(decompTrack, fsmSplitFrs);
+    
+    [~, sizeMinDecompTrack] = selTrackChecker(decompTrack, [], smConditions.minLft(iMov));
+    cntDecompTrack = table(iMov, sizeMinDecompTrack, numPassTrack);
+    numPassDecomptrackAll = vertcat(numPassDecomptrackAll, cntDecompTrack);
+    
+    %% Loop over FSM intervals
+    
+    windLast = windFirst + windAdd + numFramesFSM(iMov) - 2; % last FSM interval
+    
+    for iFr = windFirst : windLast % looping through each grouped FSM interval (e.g. 50 SM frame are grouped into 1 qFSM frame)
+        
+        % Get mask and (y,x) coordinates for each interval, from mask of corresponding FSM frame
+        maskCoordCurrFrame = [];
+        if smConditions.maskLoc(iMov) ~= 0
+            imgMask = imread([masksDirOut{1,1}(iFr + 2).folder filesep masksDirOut{1,1}(iFr + 2).name]);
+        elseif smConditions.maskLoc(iMov) == 0
+            imgMask = imread([masksDirOut{1,1}(3).folder filesep masksDirOut{1,1}(3).name]);
+        end
+        [maskCoordCurrFrame(:,2), maskCoordCurrFrame(:,1)] = find(imgMask);
+        
+        %% Split tracks into FSM intervals
+        
+        % Chop tracks into specific interval
+        frameRange = [smPropPerTimeInt{iMov,1}(iFr).smFrames(1)  smPropPerTimeInt{iMov,1}(iFr).smFrames(end)];
+        tracksCrop = cropCompTracksFR(decompTrack,frameRange);
+        
+        if isempty(tracksCrop) % if this frame interval is empty (blacked out), skip to the next frame interval
+            continue
+        end
+        
+        % construct new tracksFinal:
+        tracksFinal_new = tracksCrop;
+        tracksFinal_new = rmfield(tracksFinal_new,'oldTracksInfo');
+        
+        %% Analyze diffusion & split tracks by TIME:
+        
+        % Transient analysis & refinement (including DC-MSS) 
+        transDiffAnalysisResCrop =  basicTransientDiffusionAnalysisv1(tracksFinal_new,2,0,95); % 2nd/3rd/4th are default inputs
+        
+        % Chop by motion type (from DC-MSS) & by time (with MSS redone on chopped tracklets)
+        [refinedTrackBigSpan, measurementsBigSpan, cntTrackBigSpan, ~] = ...
+            basicTransientTrackCrop(transDiffAnalysisResCrop, tracksFinal_new, smConditions.max2TracksSize); close all;
+        
+        %% Analyze diffusion & split tracks by SPAN:
+        % Chop by span of each tracklet within "actin domains"
+        
+        [refinedTrack, measurements, numBigSpan] = basicTransientTrackChopBySpan(refinedTrackBigSpan, measurementsBigSpan, smSpanRadius);
+        
+        %% Analyze diffusion mode:
+        diffModeAnalysisRes = trackDiffModeAnalysis(refinedTrack, diffModeDividerStruct);
+        
+        %% Count number of tracks per chopping 
+        summaryNumTrack = countNumTrackletsMultChop(tracksFinal_new, transDiffAnalysisResCrop, refinedTrackBigSpan, refinedTrack, cntTrackBigSpan,numBigSpan);
+        summaryNumTrack = horzcat(table(iMov, iFr), summaryNumTrack);
+        summaryNumTrackAll = vertcat(summaryNumTrackAll, summaryNumTrack);
+        
+        %% Get list of SM in this interval
+        
+        % Convert cropped SM tracks information into matrix:
+        [trackedFeatureInfo,~,~,~,aggregStateMat] = convStruct2MatIgnoreMS(refinedTrack,1);
+        
+        % Get matrix of x/y-coordinate of SM within this specific frameRange.
+        xyInterval = cat(3,trackedFeatureInfo(:,1 : 8 : end),trackedFeatureInfo(:,2 : 8 : end));
+        
+        % Get mean position of each SM track in this interval.
+        xyMean = [nanmean(xyInterval(:,:,1),2), nanmean(xyInterval(:,:,2),2)];
+        
+        % enumerate SM (vector of indices of existing particles in this interval)
+        indxNoNan = find(~isnan(xyMean(:,1)));
+        smPropPerTimeInt{iMov,1}(iFr,1).smList = indxNoNan;
+        
+        %matrix of existing SM tracks within a particular interval
+        existTracks = xyInterval(indxNoNan,:,1);
+        
+        %% Extraction/calculation of various SM properties (many from above diffusion and assembly state analysis)
+        
+        % Mean position of SM particles in this particular FSM interval, in (x,y) coordinates
+        smPropPerTimeInt{iMov,1}(iFr,1).meanPos = [xyMean(indxNoNan,1), xyMean(indxNoNan,2)];
+        
+        % Amplitude of SM (matrix)
+        ampMat = trackedFeatureInfo(:,4 : 8 : end);
+        ampMean = nanmean(ampMat,2);
+        smPropPerTimeInt{iMov,1}(iFr,1).meanAmp = ampMean(indxNoNan);
+        
+        % motion classification for SM particle existing in this interval
+        smPropPerTimeInt{iMov,1}(iFr,1).trackClass = measurements(indxNoNan,1);
+        
+        % diffusion coefficient for SM existing in this interval
+        smPropPerTimeInt{iMov,1}(iFr,1).diffCoef = measurements(indxNoNan,3);
+        
+        % Confinement radius
+        smPropPerTimeInt{iMov,1}(iFr,1).confRad = measurements(indxNoNan,2);
+        
+        % MSS slope
+        smPropPerTimeInt{iMov,1}(iFr,1).mssSlope = measurements(indxNoNan,4);
+        
+        % Oligomeric state
+        smPropPerTimeInt{iMov,1}(iFr,1).aggregState = nanmean(aggregStateMat,2);
+        
+        % Calculate .meanDisp (mean displacement, for the track, over this
+        % interval), ignoring gap closing (i.e., i-gap-k then 1
+        % displacement is d(i,k))
+        f2fDispMagnitude = sqrt((diff(xyInterval(indxNoNan,:,1), 1, 2)) .^ 2 + ...
+            (diff(xyInterval(indxNoNan,:,2), 1, 2)) .^ 2);
+        smPropPerTimeInt{iMov,1}(iFr,1).meanDisp = nanmean(f2fDispMagnitude,2);
+        
+        % Properties from Mode analysis - TN20240320:
+        tmp = [diffModeAnalysisRes.diffMode]'; smPropPerTimeInt{iMov,1}(iFr,1).mDiffMode = tmp(indxNoNan,:); %Diffusion mode.
+        tmp = [diffModeAnalysisRes.diffCoef]'; smPropPerTimeInt{iMov,1}(iFr,1).mDiffCoef = tmp(indxNoNan,:);  % Diffusion coefficient from mean square F2F displacement
+        tmp = [diffModeAnalysisRes.msdF2F]'; smPropPerTimeInt{iMov,1}(iFr,1).mMsdF2F = tmp(indxNoNan,:);   % Mean square F2F displacement.
+        tmp = [diffModeAnalysisRes.meanPosStd]'; smPropPerTimeInt{iMov,1}(iFr,1).mMeanPosStd = tmp(indxNoNan,:);  % Mean positonal standard deviation.
+        tmp = [diffModeAnalysisRes.diffRadius]'; smPropPerTimeInt{iMov,1}(iFr,1).mDiffRadius = tmp(indxNoNan,:);  % Diffusion radius.
+        tmp = [diffModeAnalysisRes.lifetime]'; smPropPerTimeInt{iMov,1}(iFr,1).mLifetime = tmp(indxNoNan,:);  % Track lifetime.
+        
+        %% SM local density
+        
+        availFrame = min(size(smPropPerTimeInt{iMov,1}(iFr,1).smFrames,1),size(xyInterval,2)); % in case xyInterval doesn't have the full length of (fsmInterval+1)
+        
+        for iSmFrame = 1:availFrame
+            
+            % distance between all SM (of 1 frame)
+            disMatPerFrame = createDistanceMatrix([xyInterval(:,iSmFrame,1) xyInterval(:,iSmFrame,2)], ...
+                [xyInterval(:,iSmFrame,1) xyInterval(:,iSmFrame,2)]);
+            
+            % calculate local density of all SM (in this 1 frame)
+            for iCol = 1 : size(disMatPerFrame,2) % looping through all listed SM
+                
+                mtchIndex = (disMatPerFrame(:,iCol) <= smConditions.rad_density(iMov));
+                
+                % for SM that doesn't have detection at specific frame, its
+                % distance in disMatPerFrame is filled as NaN, hence its sum(mtchIndex)
+                % will be 0. For all SM that exist, sum(mtchIndex) is at
+                % least 1, because a detection's distance to itself is 0,
+                % and it always exists inside its neighborhood.
+                %
+                % If SM detection exist, input density in .smDensityPerFr;
+                % if SM detection doesn't exist, input NaN.
+                % TN 20191010
+                if  sum(mtchIndex) ~= 0
+                    smPropPerTimeInt{iMov}(iFr).smDensityPerFr(iCol,iSmFrame) = sum(mtchIndex)/...
+                        (pi*((smConditions.rad_density(iMov)) ^ 2));
+                else
+                    smPropPerTimeInt{iMov}(iFr).smDensityPerFr(iCol,iSmFrame) = NaN;
+                end
+                
+            end
+            
+        end
+        
+        % calculate local SM density per FSM interval (density = number of SM per pixel)
+        % .smDensity (over neighborhood of input-defined radius, averaging this interval)
+        smPropPerTimeInt{iMov}(iFr).meanSmDensity(:,1) = ...
+            nanmean(smPropPerTimeInt{iMov}(iFr).smDensityPerFr,2);
+        
+        %% Calculation of various other SM properties
+        
+        if isempty(indxNoNan)
+            
+            smPropPerTimeInt{iMov,1}(iFr,1).lifetime = zeros(0,1);
+            smPropPerTimeInt{iMov,1}(iFr,1).numObservations = zeros(0,1);
+            smPropPerTimeInt{iMov,1}(iFr,1).smFramesExist = zeros(0,1);
+            smPropPerTimeInt{iMov,1}(iFr,1).netVelocity = zeros(0,2);
+            smPropPerTimeInt{iMov,1}(iFr,1).netSpeed = zeros(0,1);
+            smPropPerTimeInt{iMov,1}(iFr,1).netVelAngle = zeros(0,1);
+            smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr = zeros(0,2);
+            smPropPerTimeInt{iMov,1}(iFr,1).maskDensity = 0;
+            threshMet{iMov,1}{iFr,1} = [];
+            
+        else
+            
+            for kTrack = 1 : length(indxNoNan)
+                
+                % (vector of) SM frame numbers at which this SM track exists in (in this particular FSM interval)
+                frExist = find(~isnan(existTracks(kTrack,:)))';
+                smPropPerTimeInt{iMov,1}(iFr,1).smFramesExist{kTrack,1} = frExist;
+                
+                % lifetime of this existing SM track (in a particular interval)
+                smPropPerTimeInt{iMov,1}(iFr,1).lifetime(kTrack,1) = frExist(end) - frExist(1) + 1;
+                
+                % number of observations (actual detection, not closed gap)
+                % for an existing SM track (in a particular interval)
+                smPropPerTimeInt{iMov,1}(iFr,1).numObservations(kTrack,1) = length(frExist);
+                
+                % Net velocity of this SM track (in this particular interval)
+                % net velocity = (total distance displaced (|x|,|y|) in
+                % pixels)/(total time passed (in number of SM frame intervals))
+                smPropPerTimeInt{iMov,1}(iFr,1).netVelocity(kTrack,:) = ...
+                    (xyInterval(indxNoNan(kTrack),frExist(end),:) - ...
+                    xyInterval(indxNoNan(kTrack),frExist(1),:)) / ...
+                    (smPropPerTimeInt{iMov,1}(iFr,1).lifetime(kTrack) - 1);
+                
+                % Net speed for this SM track (in this particular interval) (along the 2D plane)
+                % net speed = sqrt(dx^2 + dy^2)/time (pixel/SM frame intervals)
+                smPropPerTimeInt{iMov,1}(iFr,1).netSpeed(kTrack,1) = ...
+                    norm(smPropPerTimeInt{iMov,1}(iFr,1).netVelocity(kTrack,:));
+                
+                % net velocity angle (taken w.r.t image coordinate system)
+                % of an existing SM track (in a particular interval)
+                % range of netVelAngle = [-90, 90]
+                smPropPerTimeInt{iMov,1}(iFr,1).netVelAngle(kTrack,1) = ...
+                    atand(smPropPerTimeInt{iMov,1}(iFr,1).netVelocity(kTrack,2) / ...
+                    smPropPerTimeInt{iMov,1}(iFr,1).netVelocity(kTrack,1));
+                
+                % (x,y) coordinates of this SM at every SMI frame
+                posVect = [xyInterval(indxNoNan(kTrack),:,1)' xyInterval(indxNoNan(kTrack),:,2)']; % vector of (x,y) positions of sm track
+                smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr{kTrack,1} = posVect(frExist(1):frExist(end),:); % NaN = where Gap
+                
+                % Amplitude of this SM at every SMI frame
+                smPropPerTimeInt{iMov,1}(iFr,1).f2fAmp{kTrack,1} = ampMat(indxNoNan(kTrack),frExist(1):frExist(end))'; % NaN = where Gap
+                
+                % Randomization of SM tracks (moving SM tracks from its
+                % original location to somewhere else on the eroded mask) - TN 20220909
+                
+                if isfield(smConditions,'randFlag')
+                    switch smConditions.randFlag(iMov)
+                        case 1 % if smConditions.randFlag(iMov) == 1, then randomize track position to any location in mask ROI
+                            
+                            if ismember(round(smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,:)), [maskCoordCurrFrame(:,1),maskCoordCurrFrame(:,2)],'rows')
+                                % If current track is inside the mask,
+                                % randomize it. If current track is outside
+                                % the mask, ignore it.
+                                
+                                if ~isnan(smPropPerTimeInt{iMov,1}(iFr,1).confRad(kTrack,1))
+                                    % NaN span indicates that track only contain 1
+                                    % detection. If that's the case, do no
+                                    % randomization.
+                                    
+                                    % STEP 0: Make the image's edges 0
+                                    imgMask(1:end,[1,end]) = 0;
+                                    imgMask([1,end],1:end) = 0;
+                                    
+                                    % STEP 1: Erode current mask
+                                    se_tmp = strel('disk', round(smPropPerTimeInt{iMov,1}(iFr,1).confRad(kTrack,1)/2)); % built an element to erode by radius of SM we want to move
+                                    imgMaskErode = imerode(imgMask,se_tmp);
+                                    
+                                    % Check if mask still exist after erosion and opening
+                                    if sum(sum(imgMaskErode)) == 0 % If mask after the first erosion is completely removed
+                                        % Then we have to re-erode with smaller element.
+                                        warning('Erosion by radius/2 completely removed cell mask. Redo erosion with smaller element.')
+                                        se_tmp = strel('disk', round(smPropPerTimeInt{iMov,1}(iFr,1).confRad(kTrack,1)/4)); % built an element to erode by radius of SM we want to move
+                                        imgMaskErode = imerode(imgMask,se_tmp);
+                                    end
+                                    
+                                    se_tmp2 = strel('disk', round(smPropPerTimeInt{iMov,1}(iFr,1).confRad(kTrack,1)/4)); % built an element to erode by radius of SM we want to move
+                                    imgMaskRefined = imopen(imgMaskErode, se_tmp2); % remove the small disconnected mask from the main mask
+                                    
+                                    if sum(sum(imgMaskRefined)) == 0 % If mask after the first erosion is completely removed
+                                        % Then we have to redo erosion
+                                        warning('Opening by radius/4 completely removed cell mask. Redo opening with smaller element.')
+                                        se_tmp2 = strel('disk', round(smPropPerTimeInt{iMov,1}(iFr,1).confRad(kTrack,1)/8)); % built an element to erode by radius of SM we want to move
+                                        imgMaskRefined = imopen(imgMaskErode, se_tmp2); % remove the small disconnected mask from the main mask
+                                    end
+                                    
+                                    % STEP 2: Find a new randomized position within eroded mask
+                                    [maskCoordRefined_tmp_2, maskCoordRefined_tmp_1] = find(imgMaskRefined);
+                                    randPos_tmp = datasample(horzcat(maskCoordRefined_tmp_1, maskCoordRefined_tmp_2),1);
+                                    %figure, imshow(imgMask), hold on, scatter(randPos_tmp(1,1),randPos_tmp(1,2),'x'); % debug to make sure randomized position is within eroded mask
+                                    %scatter(smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,1),smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,2),'o'); % debug to visualize old track position (utrack & SMI-FSM report image coordinate)
+                                    
+                                    % Find displacement vector to translate SM track mean position to new position
+                                    displacementVect_tmp = randPos_tmp - smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,:);
+                                    
+                                    % Translate the SM track mean position and every SM track
+                                    % detections at each timepoint to new position
+                                    %plot(smPropPerTimeInt{iMov,1}(iFrame,1).indiPosPerFr{kTrack}(:,1),smPropPerTimeInt{iMov,1}(iFrame,1).indiPosPerFr{kTrack}(:,2),'d-','Color','b') % debug to visualize old track position (image coordinate)
+                                    
+                                    smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,:) = randPos_tmp; % equivalent to: smPropPerTimeInt{iMov,1}(iFrame,1).meanPos(kTrack,:) + displacementVect_tmp;
+                                    newTrack = smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr{kTrack} + displacementVect_tmp;
+                                    %plot(smPropPerTimeInt{iMov,1}(iFrame,1).indiPosPerFr{kTrack}(:,1),smPropPerTimeInt{iMov,1}(iFrame,1).indiPosPerFr{kTrack}(:,2),'d-','Color','y') % debug to visualize NEW track position (image coordinate)
+                                    
+                                    smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr{kTrack} = fitTrackInImg(newTrack, imgMaskRefined);
+                                    
+                                    clear se_tmp se_tmp2 imgMaskErode imgMaskRefined randPos_tmp displacementVect_tmp newTrack
+                                end % ( if ~isnan(smPropPerTimeInt{iMov,1}(iFrame,1).confRad(kTrack,1))  )
+                            end % (   ismember(round(smPropPerTimeInt{iMov,1}(iFrame,1).meanPos(kTrack,:)), [maskCoordCurrFrame(:,1),maskCoordCurrFrame(:,2)],'rows')    )
+                            
+                        otherwise % if smConditions.randFlag(iMov) == -M, then shift track position M pixels to the right.
+                            
+                            if smConditions.randFlag(iMov) < 0
+                                M = abs(smConditions.randFlag(iMov)); % shift distance
+                                % Translate the SM track mean position and every SM track
+                                % detections at each timepoint to new position
+                                smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,1) = smPropPerTimeInt{iMov,1}(iFr,1).meanPos(kTrack,1) + M; % equivalent to: smPropPerTimeInt{iMov,1}(iFrame,1).meanPos(kTrack,:) + displacementVect_tmp;
+                                smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr{kTrack}(:,1) = smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr{kTrack}(:,1) + M;
+                            end % (  if smConditions.randFlag(iMov) < 0  )
+                    end %    switch smConditions.randFlag(iMov)
+                end %   if isfield(smConditions,'randFlag')
+                
+                % Frame-to-frame displacement: - added TN20230209
+                smPropPerTimeInt{iMov,1}(iFr,1).f2fDisplacement{kTrack,1} = [diff(smPropPerTimeInt{iMov,1}(iFr,1).indiPosPerFr{kTrack,1},1,1);NaN,NaN]; % NaN = where Gap
+                smPropPerTimeInt{iMov,1}(iFr,1).f2fDisplacementMag{kTrack,1} = vecnorm(smPropPerTimeInt{iMov,1}(iFr,1).f2fDisplacement{kTrack,1},2,2);
+                smPropPerTimeInt{iMov,1}(iFr,1).f2fDisplMovAvg{kTrack,1} = movmean(smPropPerTimeInt{iMov,1}(iFr,1).f2fDisplacementMag{kTrack,1}, 5, "omitnan");
+                
+            end %(for kTrack = 1 : length(indxNoNan))
+            
+            if ~isempty(maskCoordCurrFrame(:,1))
+                
+                % find the "valid" SM tracks whose mean position is within the mask
+                threshMet{iMov,1}{iFr,1} = find(ismember(round(smPropPerTimeInt ...
+                    {iMov,1}(iFr,1).meanPos), [maskCoordCurrFrame(:,1),maskCoordCurrFrame(:,2)],'rows'));
+                
+                % calculate mask density (# of tracks per pixel)
+                % = number of valid SM tracks / area of mask
+                smPropPerTimeInt{iMov,1}(iFr,1).maskDensity = ...
+                    length(indxNoNan(threshMet{iMov,1}{iFr,1})) / length(maskCoordCurrFrame(:,1));
+                
+            else
+                
+                % if there is no mask, only find the SM that exist longer
+                % than input-defined minimum lifetime
+                threshMet{iMov,1}{iFr,1} = ...
+                    1:length(smPropPerTimeInt{iMov,1}(iFr,1).lifetime);
+                
+                smPropPerTimeInt{iMov,1}(iFr,1).maskDensity = NaN; %% SHOULD BE # OF TRACKS / IMAGE AREA (but there's no easy way of getting this info)
+                
+            end
+            
+            %% Get merging and splitting information
+            smPropPerTimeInt{iMov,1}(iFr,1).mergeInfoSpace = [];
+            for kCol = 1:(size(mergesInfo,2)-3)
+                mergeIndx = ismember(mergesInfo(:,kCol+3), smPropPerTimeInt{iMov,1}(iFr).smFrames);
+                mergeLoc = mergesInfoSpace(mergeIndx, [(2*kCol-1)  2*kCol]);
+                smPropPerTimeInt{iMov,1}(iFr,1).mergeInfoSpace = vertcat(smPropPerTimeInt{iMov,1}(iFr,1).mergeInfoSpace, mergeLoc);
+            end
+            
+            smPropPerTimeInt{iMov,1}(iFr,1).splitInfoSpace = [];
+            for kCol = 1:(size(splitsInfo,2)-3)
+                splitIndx = ismember(splitsInfo(:,kCol+3), smPropPerTimeInt{iMov,1}(iFr).smFrames);
+                splitLoc = splitsInfoSpace(splitIndx, [(2*kCol-1)  2*kCol]);
+                smPropPerTimeInt{iMov,1}(iFr,1).splitInfoSpace = vertcat(smPropPerTimeInt{iMov,1}(iFr,1).splitInfoSpace, splitLoc);
+            end
+            
+        end %(if isempty(indxNoNan))
+        
+    end %(for iFrame = windFirst : windLast)
+    
+end %(for iMov = 1 : numMovs)
+
+end
+
+%% ~~~ the end ~~~

--- a/smactinClean.m
+++ b/smactinClean.m
@@ -1,0 +1,107 @@
+function [tassmOut, indxConverted] = smactinClean(tassmIn, varName, colIndxArr, thresholdArr)
+%SMACTINCLEAN: search for observations in either speckle or single-molecule properties in tassm that are LOWER OR EQUAL TO input threshold and replace them with NaN.
+%
+% SYNOPSIS: [tassmOut, indxConverted] = smactinClean(tassmIn, varName, colIndx, threshold)
+%
+% Example: [tassmOut, indxConverted] = smactinClean(tassmIn, 'speckle', 1, 0.01)
+%
+% INPUT:    tassmIn: (array of cells) each cell contains 3 cells denoting
+%                    matrix for properties of speckle, SM, SM position.)
+%
+%           varName: (string) either exactly as:
+%                       'speckle': function looks into first cell of
+%                       tassm{i}, containing speckle properties.
+%                       'single molecule': function looks into 2nd cell of
+%                       tassm{i}, containing SM properties.
+%
+%           colIndxArr: (vector of integer) the colume index of the
+%                       property of interest 
+%                       Example: colIndxArr = [1 9]; (for speckle speed and 
+%                                speckle average speed) 
+%
+%           thresholdArr: (vector of double aka. real number) the threshold 
+%                       where value equal or below which is converted to NaN.
+%                       Example: thresholdArr = [0 0];
+%
+% OUTPUT:   tassmOut: (array of cells) each cell contains 3 cells denoting
+%                     matrix for properties of speckle, SM, SM position.)
+%
+%           indxConverted: (array of cells that contain n-by-1 vector of
+%                          integer) 1 indicates that that observation was
+%                          below threshold and converted to NaN in
+%                          tassmOut.
+%
+% Tra Ngo, Jun 2021
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Input control & variable initiations
+numCell = length(tassmIn);
+numProp = length(colIndxArr);
+
+switch varName
+    case 'speckle'
+        iProp = 1;
+    case 'single molecule'
+        iProp = 2;
+    otherwise
+        error('Unexpected input. "varName" expects only either "speckle" or "single molecule" string.')
+end
+
+% Control: length of colIndxArr has to equal length of thresholdArr
+if length(thresholdArr) ~= numProp
+    error('colIndxArr and thresholdArr inputs have to be vectors of the same length.')
+end
+
+%% Output
+tassmOut = tassmIn;
+indxConverted = cell(numCell,1);
+
+for iCol = 1:numProp % loop through each properties of interest
+    
+    % grab colume index and according threshold to process
+    colIndx = colIndxArr(iCol);
+    threshold = thresholdArr(iCol);
+    
+    for iCell = 1:numCell % loop through each cell in tassmIn
+        
+        % skip empty cell
+        if isempty(tassmIn{iCell,1})
+            continue
+        end
+        
+        % grab colume containing all observations for property of interest from
+        % current cell:
+        allObs = tassmIn{iCell,1}{1,iProp}(:,colIndx);
+        
+        % find index of observations that does not meet the input threshold:
+        indxNan = (allObs <= threshold);
+        
+        % replace the observations that does not meet the threshold with NaN:
+        tassmOut{iCell,1}{1,iProp}(indxNan,colIndx) = NaN;
+        
+        % output index of observatioins that does not meet input threshold for
+        % current cell:
+        indxConverted{iCell,1}{1,iCol} = indxNan;
+        
+    end
+end
+
+end

--- a/smactinMat.m
+++ b/smactinMat.m
@@ -1,0 +1,313 @@
+function [tassm, matchindx] = smactinMat(combinePropPerTimeInt,combineConditions,smactinFlag, diffMode)
+%SMACTINMAT   Converts selected fields from combinePropPerTimeInt into data matrix format
+%
+%SYNOPSIS: [tassm,matchindx] = smactinMat(combinePropPerTimeInt,combineConditions,smactinFlag, diffMode)
+%
+%INPUT: combinePropPerTimeInt: (n x 1 cell array of structures) various 
+%                              properties of both single molecules and actin.
+%                              (see smactinPropPerTimeInt.m for details.)
+%
+%         combineConditions  : (structure) parameters for combinding SM
+%                              tracks from SMI and speckles from FSM.
+%                              (see smactinPropPerTimeInt.m for details.)
+%                               Important Note: function is only using the
+%                               2nd cell for each movie.
+%
+%               smactinFlag  : (structure) flags indicating methods of SMI-FSM combination
+%                              (see smactinPropPerTimeInt.m for details.)
+%                              Contains the following field:
+%                              .combFlag: (vector of integers from 1 to 10) flag
+%                                  indicating how to combine SMI-FSM properties
+%                                  IMPORTANT: Only .combFlag = 10 is
+%                                  updated.
+%
+%               diffMode     : (logical. Optional.) Flag indicating whether diffusion
+%                              mode analysis was performed upstream of
+%                              SMI-FSM analysis. Input diffMode is only
+%                              implemented in cases when
+%                              smactinFlag.combFlag(iMov)={7,10}
+%                              Default: input [] and this flag will be
+%                              automatically checked in
+%                              combinePropPerTimeInt.
+%                              = 0 indicates that diffModeAnalysis was not performed.
+%                              = 1 indicates that diffModeAnalysis was performed.
+%
+%OUTPUT: tassm :   (n x 1 cell array of cells) Each cell contains 3 x 1
+%                  cells, containing data matrix of SM tracklets and
+%                  speckle properties:
+%                       Cell {1,1}: (k observations x 9 properties) Data
+%                       matrix of speckle properties with columns as:
+%                       1: Local speckle displacement magnitude (also 'speckle speed')
+%                       2: Speckle co-movement (also 'speckle movement coherence)
+%                       3: Local speckle density
+%                               > expect 0 if SM is not matched to speckle
+%                               > expect NaN if density value is outlier
+%                       4: Speckle lifetime
+%                       5: Local speckle intensity (also 'ILmax')
+%                       6: Local speckle background intensity (also 'IBkg')
+%                       7: speckle corrected intensity (also 'ILmaxCorrected')
+%                       8: speckle corrected background intensity (also 'IBkgCorrected')
+%                       9: Local speckle average displacement magnitude
+%
+%                       Cell {2,1}: (k observations x 7 properties) Data
+%                       matrix of SM properties with columns as:
+%                       1: SM net speed
+%                       2: SM intensity
+%                       3: SM diffusion coefficient
+%                       4: SM density
+%                       5: SM spatial span (previously called "smDiffusionRadius")
+%                       6: SM apparent assembly state (oligomerization state)
+%                       7: SM mss Slope
+%                       8 - 13: from Mode analysis, added TN Mar2024
+%                       8: SM Diffusion coefficient from mean square F2F displacement 
+%                       9: SM Diffusion radius
+%                       10: SM Mean square F2F displacement 
+%                       11: SM Mean positional standard deviation
+%                       12: SM lifetime
+%                       13: SM Mode (1, 2, ...) 
+%                       14: SM diffusion type (motion classification by MSS)
+%
+%                       Cell {3,1}: (k observation x 2) SM tracklet mean
+%                       position as reported by field .smMeanPos: (x/y-coordinates)
+%
+%      matchindx: indices of speckles,ks, or sms matching to an object;
+%                         empty if many neighbors matching is performed.
+%
+%GLOSSARY:  SMI   : single molecule imaging
+%           SM    : single molecule
+%           FSM   : fluorescent speckle microscopy
+%           tassm : total attributes speckles and single molecules
+%           nn    : nearest neighbors (actin speckle from FSM)
+%           object: SM (referring to its attributes)
+%
+%REMARKS: Properties available for concatenation are (what gets concatenated
+%                     depends on combFlag:
+%
+%              kinetic score                kinetic score density
+%
+%              speckle speed                speckle density
+%              speckle movement coherence
+%
+%              sm mean displacement              sm mean amplitude
+%              sm diffusion coefficient          sm confinement radius (applicable only for immobile/confined sms)
+%              sm density (not used currently)   sm net speed
+%              sm comovement angle (not used currently)
+%
+% Deryl Tschoerner, May 2018. Modified by Tra Ngo & Khuloud Jaqaman.
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+%% Inputs & variable initialization
+if ~exist('diffMode ','var')|| isempty(diffMode)
+    diffMode = checkStructModeAnalysis(combinePropPerTimeInt{1}{1,2}); %TN20240327
+end
+
+numMovs = size(combinePropPerTimeInt,1);
+tassm = cell(numMovs,1);
+matchindx = tassm; % this variable is only used when smactinFlag.match == 1
+
+%{
+    % TN20220728: remove obsolete option smactinFlag.match == 1
+    %
+    % if smactinFlag.match == 1
+    %     iMatch = 1;
+    % elseif smactinFlag.match == 2
+    %     iMatch = 2;
+    % else
+    %     error('error:: invalid match parameter')
+    % end
+%}
+iMatch = 2;
+
+for iMov = 1 : numMovs
+    
+    wind1st = combineConditions.firstFsmFrame(iMov);
+    if isempty(combinePropPerTimeInt{iMov})
+        continue
+    end
+    
+    iComb = 1; %for iComb = 1 : length(smactinFlag.combFlag(iMov)) %1 : size(combinePropPerTimeInt,2)
+    
+    switch smactinFlag.combFlag(iMov)
+        %{
+%             case 3
+%                 %concatenate nn: sm, object: speckle attributes
+%                 tassm{iMov,iComb}{1} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanDisp) ... (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smNetSpeed) ... (:,2)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanAmp) ...  (:,3)
+%                     %vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smDensity) ... (:,4)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).diffCoef) ...   (:,5)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).confRad)...     (:,6)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).trackClass)];  %(:,7)
+%
+%                 tassm{iMov,iComb}{2} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleSpeed) ...     (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).matchAngle) ...       (:,2)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleDensity)]; ... (:,3)
+%
+%             case 6
+%                 %concatenate nn: sm, object: ks attributes
+%                 tassm{iMov,iComb}{1} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanDisp) ... (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smNetSpeed) ... (:,2)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanAmp) ...  (:,3)
+%                     %vertcat(combinePropPerTimeInt{iMov,iComb}{iNN}(wind1st : end).smDensity) ...    (:,4)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).diffCoef) ...   (:,5)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).confRad)...     (:,6)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).trackClass)];  %(:,7)
+%
+%                 tassm{iMov,iComb}{2} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScore) ...       (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScoreDensity)]; %(:,2)
+%
+%             case 2
+%                 %concatenate nn: ks, object: actin attributes
+%                 tassm{iMov,iComb}{1} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScore) ...       (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScoreDensity)]; %(:,2)
+%
+%                 tassm{iMov,iComb}{2} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleSpeed) ...     (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).matchAngle) ...       (:,2)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleDensity)]; ... (:,3)
+%
+%             case 8
+%                 %concatenate nn: sm, object: ks attributes
+%                 tassm{iMov,iComb}{1} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScore)]; ...       (:,1)
+%                     ...vertcat(combinePropPerTimeInt{iMov,iComb}{iNN}(wind1st : end).kinScoreDensity)];  %(:,2)
+%
+%                 tassm{iMov,iComb}{2} = [ ...
+%                     ...vertcat(combinePropPerTimeInt{iMov,iComb}{iNN}(wind1st : end).smMeanDisp) ... (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smNetSpeed) ... (:,2)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanAmp) ...  (:,3)
+%                     ...vertcat(combinePropPerTimeInt{iMov,iComb}{iNN}(wind1st : end).smDensity) ...  (:,4)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).diffCoef) ...   (:,5)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).confRad)...     (:,6)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).trackClass)];  %(:,7)
+%
+%             case 4
+%                 %concatenate nn: actin, object: ks attributes
+%                 tassm{iMov,iComb}{1} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleSpeed) ...  (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).matchAngle) ...    (:,2)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleDensity)]; %(:,3)
+%
+%                 tassm{iMov,iComb}{2} = [ ...
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScore) ...       (:,1)
+%                     vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).kinScoreDensity)]; %(:,2)
+        %}
+        case {7,10}
+            %% Speckle
+            tassm{iMov,iComb}{1} = [ ...
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleSpeed), ...         (:,1)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleMvmtCohere), ...    (:,2)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleDensity), ...      %(:,3)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleLifetime), ...     %(:,4)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).ILmax), ...               %(:,5)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).IBkg), ...                %(:,6)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).ILmaxCorrected), ...      %(:,7)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).IBkgCorrected),...        %(:,8)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).speckleSpeedAveMag)];     %(:,9)
+            
+            %% SM
+            tassm{iMov,iComb}{2} = [ ...
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smNetSpeed), ...    (:,1)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanAmp), ...     (:,2)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).diffCoef), ...      (:,3)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smDensity), ...     (:,4)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).confRad), ...       (:,5)
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smAggregState)];  % (:,6)
+            
+            if isfield(combinePropPerTimeInt{iMov,iComb}{iMatch}, 'mssSlope') % for backward compartibility as mssSlope was added later
+                tassm{iMov,iComb}{2} = horzcat(tassm{iMov,iComb}{2}, ...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).mssSlope));
+            end
+            
+            if diffMode % TN20240327: if diffusion mode was run, add its associated fields
+                tassm{iMov,iComb}{2} = horzcat(tassm{iMov,iComb}{2}, ...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smModeDiffCoef),...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smDiffRadius),...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smModeMsdF2f),...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanPosStd),...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smLifetime), ...
+                    vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMode));  
+            end
+            
+            % IMPORTANT ASSUMPTION: trackClass always have to be the last column!
+            tassm{iMov,iComb}{2} = horzcat(tassm{iMov,iComb}{2}, ...
+                vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).trackClass));
+            
+            %% SM positions
+            tassm{iMov,iComb}{3} = vertcat(combinePropPerTimeInt{iMov,iComb}{iMatch}(wind1st : end).smMeanPos);
+            
+            %{
+            % not sure what's going on here?? - TN20201013
+            case 10
+                %concatenate nn: actin/ks, object: sm attributes
+                tassm{iMov,iComb}{1} = [tassm{iMov,8}{1} tassm{iMov,7}{1}]; ... (:,1:3)
+                    tassm{iMov,iComb}{2} = tassm{iMov,8}{2};                       %(:,1:5)
+                %}
+            
+    end % switch smactinFlag.combFlag(iMov)
+    
+    if iMatch == 1
+        
+        %during nn analysis, bisect nns that match or unmatch under
+        %combineConditions. otherwise this should not be processed
+        if iComb == 10
+            
+            matchindx{iMov,iComb} = matchindx{iMov,7} & matchindx{iMov,8};
+        else
+            %%% PUT BACK THE iMATCH %%%
+            matchindx{iMov,iComb} = vertcat(combinePropPerTimeInt{iMov,iComb}(wind1st : end).dist_match) <= ...
+                combineConditions.matchRadius(iMov);
+        end
+    end % if iMatch == 1
+    
+    
+end % for iMov = 1 : numMovs
+
+end
+
+function modeAnalysisFlag = checkStructModeAnalysis(analyzedStructure)
+%CHECKSTRUCTMODEANALYSIS: check if a structure contains fields that indicate whether Mode Analysis was done or not.
+%
+%INPUT: analyzedStructure: various properties of both SM and actin
+%                          (see smactinPropPerTimeInt.m for details.)
+%
+%OUTPUT: modeAnalysisFlag: (logical) true = mode analysis was performed
+%                          false = mode analysis was not performed (could
+%                          not find ALL the mode-associated fields)
+%
+%Tra Ngo, March 2024
+modeAnalysisFlag = true;
+fieldsOfModeAnalysis = {'smModeDiffCoef', 'smDiffRadius', 'smModeMsdF2f', 'smMeanPosStd', 'smLifetime'};
+for i = 1:length(fieldsOfModeAnalysis)
+    if ~isfield(analyzedStructure, fieldsOfModeAnalysis{i})
+        modeAnalysisFlag = false;
+        warning(['Mode analysis not done. Field ' fieldsOfModeAnalysis{i} ' not found.'])
+        return
+    end
+end
+end
+
+%% The end %%

--- a/smactinPropPerTimeInt.m
+++ b/smactinPropPerTimeInt.m
@@ -1,0 +1,558 @@
+function combinePropPerTimeInt = smactinPropPerTimeInt(smPropPerTimeInt,...
+    actinPropPerTimeInt,combineConditions,threshMet,smactinFlag)
+%SMACTINPROPPERTIMEINT : put together single molecule tracklets and associated local actin speckle properties in SM-centric strategy
+%
+%SYNOPSIS: combinePropPerTimeInt = smactinPropPerTimeInt(smPropPerTimeInt,...
+%    actinPropPerTimeInt,combineConditions,threshMet,smactinFlag)
+%
+%INPUT: smPropPerTimeInt  : (n x 1 cell array of structures) SMI arm
+%                           analysis results of SMI-FSM analysis for n
+%                           movies; contains various properties of SM. 
+%                           (see output of smPropPerTimeInterval.m for details).
+%
+%     actinPropPerTimeInt : (n x 1 cell array of structures) FSM arm
+%                           analysis results of SMI-FSM analysis for n
+%                           movies; each structure contain speckle
+%                           properties for m FSM intervals. 
+%                           (see output of actinPropPerTimeInterval.m for details).
+%
+%       combineConditions : vector of structures with various fields imposing
+%                           restrictions to associate SM and actin speckles.
+%
+%                       .matchRadius   : (number vector) radius of SM
+%                                        neighborhood for matching to
+%                                        neighboring speckles.
+%                                       Example: .matchRadius = 3.5 (empirically 
+%                                       determined from camera chromatic shift)
+%
+%                       .fsmInterval   : number of SM frames to be associated with 
+%                                        FSM speckle frame (AKA per FSM frame).
+%                                       Example: .fsmInterval = 50
+%
+%                       .firstFsmFrame : the first frame of speckles that should be
+%                                        considered for matching to the start of SM movie.
+%                                       Example: .firstFsmFrame = 2 (for
+%                                       darkframe-scheme dataset where the
+%                                       first FSM interval would only
+%                                       contain spurious meaningless SM
+%                                       detection)
+%
+%                       .matchFsmIntShift: (array) the number of FSM interval
+%                                       missing from SM input. (this is
+%                                       different from empty SM interval)
+%
+%               threshMet : vector of cell vectors containing SM indices
+%                           that survived a minimum lifetime (observations)
+%                           threshold and exist within a mask obtained from
+%                           qFSM. If input is [], then all SM is considered
+%                           inside the mask.
+%
+%             smactinFlag : (structure) flags describing the method by
+%                           which SM tracklets and actin speckles are
+%                           associated spatially; contains the following
+%                           field:
+%
+%                       .combFlag: integer with value either 7 (to match SM
+%                                  to speckles based on average SM
+%                                  position) or 10 (to match SM to speckles
+%                                  based on frame-by-frame SM position).
+%
+%
+%OUTPUT: combinePropPerTimeInt: Cell array with length = number of movies.
+%                           Each cell contains two cells. First cell
+%                           contains individual matched speckle
+%                           information per single-molecule. Second cell
+%                           contains average matched speckle information per
+%                           single-molecule.
+%
+% NOTE: The following fields belong to structures contained within mentioned column
+%       of cells; i.e. at end of each field description. Four categories of fields
+%
+% 1. Single-Molecules
+%               smList: List of particles that exist in the window of time
+%                       for time-averaging                
+%
+%           .smMeanPos: Mean position (x/y-coordinates) per particle in the
+%                       window for time-averaging              
+%
+%          .smMeanDisp: mean frame-to-frame displacement for all SM
+%                       thresholding survivors in the window of
+%                       time-averaging (pixels)              
+%
+%         .smNetVelocity: SM velocity vector  per frame averaged across a
+%                       particular interval               
+%
+%          .smNetSpeed: net speed for all SM thresholding survivors within 
+%                       a particular interval. (pixels/SM frame)                    
+%
+%           .smMeanAmp: mean intensity of a SM track during a particular
+%                       window of time                             
+%
+%          .trackClass: classification of all tracks based on moment scaling
+%                       spectrum analysis
+%                       = 0 : immobile
+%                       = 1 : confined brownian
+%                       = 2 : pure brownian (free diffusion)
+%                       = 3 : directed motion                      
+%
+%            .diffCoef: diffusion coefficient with row number corresponding
+%                       to particle index                          
+%
+%             .confRad: max pairwise distance of localizations,
+%                       with row number corresponding to particle index      
+%
+%   .smComovementAngle: angle of comovement between the receptor and it nn
+%                       speckle or SM                              
+%
+%      .smIndiPosPerFr: list of SM position for each SM frame (group of ~51
+%                       frames per interval)                      
+%
+%            .mssSlope: SM mss slope (added TN Dec2022/Jan2023)
+%
+%    .smModeDiffRadius: diffusion radius calculated by Mode Analysis
+%                       (similar to confinement radius of immobile,
+%                       confined particle (TN 20240323))
+%
+% 2. Speckles
+%         .speckleList: List of speckles that exist in the frame
+%                                                                         
+%          .specklePos: The speckle position for a particular FSM frame
+%                       (pixels)                             
+%     .speckleVelocity: The speckle velocity from a frame to the
+%                       following frame (pixels / receptor frame)  
+%
+%        .speckleSpeed: speckle speed from a particular FSM frame to the
+%                       following frame (pixels / receptor frame)  
+%
+%     .spklMtchPerSmFr: list of speckles matched per sm frame (group of ~51
+%                       frames per interval)                             
+%
+% 3. Kinetic Scores
+%         .kinScorePos: The positions at which we have kinetic scores
+%                       (units: pixels)                             
+%
+%            .kinScore: The kinetic score from the qFSM package     
+%
+% 4. Miscellaneous
+%         .maskDensity: The number of speckles within a mask divided
+%                       by the number of pixels comprising the mask    
+%
+%          .dist_match: Distance of a particular nn or collection of nns
+%                       depending on which structure                   
+%
+%                 .num: Number of neighbors contained within a specified
+%                       disc                                           
+%
+%           .rad_match: Matching radius to form disc and obtain neighbors
+%                       for each speckle, kinetic score, or sm         
+%
+%GLOSSARY:  SM  : single molecule
+%           SMI : sinlge molecule imaging
+%           QFSM: quantitative Fluorescent Speckle Microscopy
+%           FL  : full-length (refer to compTrack pre-chopping)
+%
+% Deryl Tschoerner, February 2018
+% Tra Ngo, modified Oct 2019
+% Khuloud Jaqaman, July 2021, heavily modified to clean up and fix some bugs
+%
+%NOTE KJ 20210716: In the (near) future, change the output of
+%smPropPerTimeInterval such that only the information of particles inside
+%the mask is retained. When this change is made there, then this function
+%must be changed so that it no longer needs/uses threshMet.
+%
+% Copyright (C) 2025, Jaqaman Lab - UTSouthwestern 
+%
+% This file is part of SMI-FSM.
+% 
+% SMI-FSM is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+% 
+% SMI-FSM is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with SMI-FSM.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% 
+
+
+
+%% Const & variable initiation
+numMovs = length(actinPropPerTimeInt);
+fsmFrames = nan(numMovs,1);
+smIntervals = nan(numMovs,1);
+if ~isfield(combineConditions, 'matchFsmIntShift')
+    combineConditions.matchFsmIntShift = zeros(numMovs,1);
+end
+
+
+%% Output
+combinePropPerTimeInt = cell(numMovs,1);
+
+%% Calculation & matching:
+
+for iMov = 1 : numMovs % loop through each movie
+    
+    % If no speckles or single-molecules in this movie: no analysis; this row (AKA cell) will be empty.
+    if isempty(actinPropPerTimeInt{iMov,1}) || isempty(smPropPerTimeInt{iMov,1})
+        continue
+    end
+    
+    
+    %% Add empty rows to SM property input structure to match the FSM interval 1-to-1
+    fieldNames = fieldnames(smPropPerTimeInt{iMov,1})';
+    tmp = [fieldNames; cell(1, length(fieldNames))];
+    additionalRows = repmat(struct(tmp{:}),combineConditions.matchFsmIntShift(iMov),1);
+    try
+        smPropPerTimeIntCurr = vertcat(additionalRows, smPropPerTimeInt{iMov});
+    catch % Try transposing the structure. I am not sure why the size is [1 10] vs [10 1]
+        smPropPerTimeIntCurr = vertcat(additionalRows, smPropPerTimeInt{iMov}.');
+    end
+    % intervals of frames per movie
+    fsmFrames(iMov) = length(actinPropPerTimeInt{iMov});
+    smIntervals(iMov) = length(smPropPerTimeIntCurr);
+
+    %% single molecule property assignment (+ speckle density within mask):
+    
+    %initialization
+    combinePropPerTimeInt{iMov}{1} = repmat(struct('speckleMaskDensity',[],'rad_match', ...
+        combineConditions.matchRadius(iMov),'num_match',[],'dist_match',[]),fsmFrames(iMov) - 1, 1);
+    
+    % Looping over the time windows to be considered.
+    % Reminder: if combineConditions.firstFsmFrame = 2, then 1st SM
+    % interval is skipped, since we pad the 1st interval to obtain
+    % rate information for speckles (in previous analysis).
+    for k = combineConditions.firstFsmFrame(iMov) : smIntervals(iMov)
+        
+        % density of speckles within mask
+        combinePropPerTimeInt{iMov}{1}(k).speckleMaskDensity = actinPropPerTimeInt{iMov}(k).speckleMaskDensity;
+        
+        %single-molecule properties
+        if isempty(threshMet) % if SM w/in mask is handled in previous step, take all listed SM
+            combinePropPerTimeInt{iMov}{1}(k).smList = [1:length(smPropPerTimeIntCurr(k).smList)]';
+        else % for backward compartibility
+            combinePropPerTimeInt{iMov}{1}(k).smList = threshMet{iMov}{k};
+        end
+        tmp = combinePropPerTimeInt{iMov}{1}(k).smList;
+        
+        combinePropPerTimeInt{iMov}{1}(k).smMeanPos     = smPropPerTimeIntCurr(k).meanPos(tmp,:);
+        combinePropPerTimeInt{iMov}{1}(k).smNetSpeed    = smPropPerTimeIntCurr(k).netSpeed(tmp,:);
+        combinePropPerTimeInt{iMov}{1}(k).smMeanAmp     = smPropPerTimeIntCurr(k).meanAmp(tmp);
+        combinePropPerTimeInt{iMov}{1}(k).smLifetime    = smPropPerTimeIntCurr(k).lifetime(tmp);
+        combinePropPerTimeInt{iMov}{1}(k).diffCoef      = smPropPerTimeIntCurr(k).diffCoef(tmp);
+        combinePropPerTimeInt{iMov}{1}(k).smMeanDisp    = smPropPerTimeIntCurr(k).meanDisp(tmp);
+        combinePropPerTimeInt{iMov}{1}(k).smNetVelocity = smPropPerTimeIntCurr(k).netVelocity(tmp,:);
+        combinePropPerTimeInt{iMov}{1}(k).confRad       = smPropPerTimeIntCurr(k).confRad(tmp);
+        
+        combinePropPerTimeInt{iMov}{1}(k).trackClass    = smPropPerTimeIntCurr(k).trackClass(tmp);
+        if isfield(smPropPerTimeIntCurr(k),'mssSlope') % check if .mssSlope is a field b/c it's only added later on
+            combinePropPerTimeInt{iMov}{1}(k).mssSlope = smPropPerTimeIntCurr(k).mssSlope(tmp);
+        end
+        
+        if isfield(smPropPerTimeIntCurr(k),'aggregState') % check if .aggregState is a field b/c it's only added later on
+            combinePropPerTimeInt{iMov}{1}(k).smAggregState = smPropPerTimeIntCurr(k).aggregState(tmp);
+        end
+        
+        % FRAME-TO-FRAME ANALYSIS:
+        if isfield(smPropPerTimeIntCurr(k),'meanSmDensity')
+            % new field for smDensity per frame was added after Jan 2023,
+            % causing the field name change of .smDensity to .meanSmDensity
+            combinePropPerTimeInt{iMov}{1}(k).smDensity = smPropPerTimeIntCurr(k).meanSmDensity(tmp);
+            combinePropPerTimeInt{iMov}{1}(k).smDensityPerFr = smPropPerTimeIntCurr(k).smDensityPerFr(tmp);
+        else
+            combinePropPerTimeInt{iMov}{1}(k).smDensity = smPropPerTimeIntCurr(k).smDensity(tmp);
+        end
+        combinePropPerTimeInt{iMov}{1}(k).smIndiPosPerFr = smPropPerTimeIntCurr(k).indiPosPerFr(tmp);
+        
+        % CHECK FOR MODE ANALYSIS: - TN20240324
+        % If no mode analysis was implemented, make these fields NaN.
+        modeFlag = isfield(smPropPerTimeIntCurr(k),'mDiffMode') && ...
+           isfield(smPropPerTimeIntCurr(k),'mDiffRadius') && ...
+           isfield(smPropPerTimeIntCurr(k),'mMsdF2F') && ...
+           isfield(smPropPerTimeIntCurr(k),'mMeanPosStd') && ...
+           isfield(smPropPerTimeIntCurr(k),'mLifetime') && ...
+           isfield(smPropPerTimeIntCurr(k),'mDiffMode');
+       
+        if modeFlag
+            combinePropPerTimeInt{iMov}{1}(k).smMode = smPropPerTimeIntCurr(k).mDiffMode(tmp); % Diffusion Mode classification (1 or 2)
+            combinePropPerTimeInt{iMov}{1}(k).smModeDiffCoef = smPropPerTimeIntCurr(k).mDiffCoef(tmp); % Diffusion coefficient from mean square F2F displacement. (previously .smDiffCoefF2F)
+            combinePropPerTimeInt{iMov}{1}(k).smDiffRadius   = smPropPerTimeIntCurr(k).mDiffRadius(tmp); % Diffusion radius (previously .smDiffRad)
+            combinePropPerTimeInt{iMov}{1}(k).smModeMsdF2f   = smPropPerTimeIntCurr(k).mMsdF2F(tmp);   % Mean square F2F displacement
+            combinePropPerTimeInt{iMov}{1}(k).smMeanPosStd   = smPropPerTimeIntCurr(k).mMeanPosStd(tmp); % Mean positional standard deviation
+            combinePropPerTimeInt{iMov}{1}(k).smLifetime     = smPropPerTimeIntCurr(k).mLifetime(tmp); % Track lifetime
+        else 
+            combinePropPerTimeInt{iMov}{1}(k).smMode = NaN;
+            combinePropPerTimeInt{iMov}{1}(k).smModeDiffCoef = NaN;
+            combinePropPerTimeInt{iMov}{1}(k).smDiffRadius = NaN;
+            combinePropPerTimeInt{iMov}{1}(k).smModeMsdF2f = NaN;
+            combinePropPerTimeInt{iMov}{1}(k).smMeanPosStd = NaN;
+            combinePropPerTimeInt{iMov}{1}(k).smLifetime = NaN;
+            
+        end
+        
+    end %(for k = combineConditions.firstFsmFrame(iMov) : smIntervals(iMov))
+    
+    combinePropPerTimeInt{iMov}{2} = combinePropPerTimeInt{iMov}{1};
+    
+    %% nn speckle property assignment:
+    
+    for k = combineConditions.firstFsmFrame(iMov): smIntervals(iMov) % looping over time windows
+        
+        smMatchPt = smPropPerTimeIntCurr(k).meanPos(combinePropPerTimeInt{iMov}{1}(k).smList,:);
+        actinMatchPt = actinPropPerTimeInt{iMov}(k).speckleInitPos;
+        
+        % if no speckle or no sm in this time window, then no analysis and go to the next time window.
+        if isempty(actinMatchPt) || isempty(smMatchPt)
+            continue
+        end
+        
+        distMat = createDistanceMatrix(actinMatchPt, smMatchPt);
+        
+        for iCol = 1 : size(distMat,2) % given SM objects, find speckle nns and get their properties
+            
+            switch smactinFlag.combFlag(iMov)
+                
+                case 7 % match neighboring speckles based on average SM position
+                    
+                    nn = [];
+                    mtchindx = find(distMat(:,iCol) <= combinePropPerTimeInt{iMov}{1}(k).rad_match);
+                    [mtchIndxBySmFr,matSpkAtSmFrIndx] = deal(mtchindx); %KJ 20210709: Add this here, because otherwise below code will crash for this case
+                    
+                case 10 % match neighboring speckles based on frame-by-frame SM position
+                    
+                    nn = [];
+                                        
+                    trackDistMat = createDistanceMatrix(actinPropPerTimeInt{iMov}(k).speckleInitPos, ...
+                        combinePropPerTimeInt{iMov}{1}(k).smIndiPosPerFr{iCol,1});
+                    mtchSmFrIndxMat = trackDistMat <= combinePropPerTimeInt{iMov}{1}(k).rad_match;
+                    
+                    maxNumSpek = max(sum(mtchSmFrIndxMat)); % get max number of speckles matched at a single frame
+                    numSmFr = size(trackDistMat, 2); % get SM track lifetime
+                    
+                    matSpkAtSmFr = nan(maxNumSpek, numSmFr); % initialize matrix containing matched speckles
+                    
+                    for iTime = 1:numSmFr
+                        spekInd = find(mtchSmFrIndxMat(:,iTime) == 1);
+                        matSpkAtSmFr(1:length(spekInd),iTime) = ...
+                            actinPropPerTimeInt{iMov}(k).speckleList(spekInd);
+                    end
+                    
+                    combinePropPerTimeInt{iMov}{1}(k).([nn 'spklMtchPerSmFr']){iCol,1} = matSpkAtSmFr;
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'spklMtchPerSmFr']){iCol,1} = matSpkAtSmFr;
+                    
+                    mtchList = unique(matSpkAtSmFr);
+                    mtchListLogic = ~isnan(mtchList);
+                    mtchID = mtchList(mtchListLogic);
+                    mtchID = mtchID(:); %KJ 200204: make sure that mtchID is always a column vector
+                    
+                    mtchindx = nan(size(mtchID));
+                    for iMtchIndx = 1:length(mtchID)
+                        mtchindx(iMtchIndx) = ...
+                            find(actinPropPerTimeInt{iMov}(k).speckleList == mtchID(iMtchIndx));
+                    end
+                    
+                    %KJ 20210712: get speckle indices first in matrix
+                    %format of speckle matching (per frame)
+                    matSpkAtSmFrIndx = NaN(size(matSpkAtSmFr));
+                    indxGood = find(~isnan(matSpkAtSmFr));
+                    indxGood = indxGood(:)';
+                    for iSpk = indxGood
+                        matSpkAtSmFrIndx(iSpk) = find(actinPropPerTimeInt{iMov}(k).speckleList == matSpkAtSmFr(iSpk));
+                    end
+                    
+                    % TN 20210601: get full list of speckles matched to sm by frame (with repeat, if
+                    % sm is matched to the same speckle multiple times)
+                    %KJ 20210712: Because mapping has already been done at
+                    %matrix level, no need for mapping here now
+
+                    mtchIndxBySmFr = matSpkAtSmFrIndx(~isnan(matSpkAtSmFrIndx));
+                    mtchIndxBySmFr = mtchIndxBySmFr(:);
+                   
+            end
+            
+            % Retrieve indices of nearest neighbors
+            switch smactinFlag.combFlag(iMov)
+                
+                case 7 % assign nn speckle indices based on average SM position
+                    combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleList']){iCol,1} = ...
+                        actinPropPerTimeInt{iMov}(k).speckleList(mtchindx);
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleList']){iCol,1} = ...
+                        combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleList']){iCol,1};
+                    
+                case 10 % assign nn speckle indices based on frame-by-frame matching
+                    combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleList']){iCol,1} = ...
+                        mtchID;
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleList']){iCol,1} = ...
+                        mtchID;
+            end
+            
+            % Distances of neighbors:
+            combinePropPerTimeInt{iMov}{1}(k).dist_match{iCol,1} = distMat(mtchindx,iCol); %KJ 200204 comment: This is distance from mean position, even when matching is done based on frame-by-frame position
+            
+            % Number of neighbors
+            combinePropPerTimeInt{iMov}{1}(k).num_match(iCol,1) = ...
+                length(combinePropPerTimeInt{iMov}{1}(k).dist_match{iCol,1});
+            
+            % Assignment of neighboring speckle properties to the SM object
+            % Changed average to weighted average (Tra 20210602 and KJ 20210708-20210712)
+            
+            %Position
+            
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'specklePos']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).speckleInitPos(mtchindx,:);
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'specklePos'])(iCol,:) = ...
+                [mean(actinPropPerTimeInt{iMov}(k).speckleInitPos(mtchIndxBySmFr,1)), ...
+                mean(actinPropPerTimeInt{iMov}(k).speckleInitPos(mtchIndxBySmFr,2))];
+            
+            %Movement
+            
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleVelocity']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).speckleVelocity(mtchindx,:);
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleVelocity'])(iCol,:) = ...
+                [nanmean(actinPropPerTimeInt{iMov}(k).speckleVelocity(mtchIndxBySmFr,1)), ...
+                nanmean(actinPropPerTimeInt{iMov}(k).speckleVelocity(mtchIndxBySmFr,2))];
+            
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleSpeed']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).speckleSpeed(mtchindx) ...
+                / combineConditions.fsmInterval(iMov);
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleSpeed'])(iCol,1) = ...
+                sqrt(sum(combinePropPerTimeInt{iMov}{2}(k).speckleVelocity(iCol,:) .^ 2)) ...
+                / combineConditions.fsmInterval(iMov); % net speed
+            
+            %KJ 20210712: the above speed is net speed, i.e. magnitude of
+            %net velocity. This here is the average speed regardless of
+            %direction. This field is needed to calculate movement
+            %coherenece parameter below.
+            speckleSpeedVec = actinPropPerTimeInt{iMov}(k).speckleSpeed(mtchIndxBySmFr,1);
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleSpeedAveMag'])(iCol,1) = ...
+                nanmean(speckleSpeedVec) / combineConditions.fsmInterval(iMov);
+
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleMvmtCohere']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).speckleMvmtCohere(mtchindx);
+            
+            %KJ 20210709: if there is only one speckle neighbor, then
+            %speckle movement coherence is not relevant
+            %20210712: same if there is at most one speckle with nonzero velocity
+            if length(mtchindx) == 1 || length(find(speckleSpeedVec>0)) <= 1 
+                combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleMvmtCohere'])(iCol,1) = NaN;
+            else
+                combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleMvmtCohere'])(iCol,1) = ...
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleSpeed'])(iCol,1) ...
+                    / combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleSpeedAveMag'])(iCol,1);
+            end
+            
+            % KJ 20210709: Angle between speckle velocity (individual or
+            % net) and SM velocity - Major bug fixes
+            if isempty(mtchindx)
+                
+                combinePropPerTimeInt{iMov}{1}(k).([nn 'smComvmtAngle']){iCol,1} = [];
+                combinePropPerTimeInt{iMov}{2}(k).([nn 'smComvmtAngle'])(iCol,:) = NaN;
+                
+            else
+                
+                vel1 = combinePropPerTimeInt{iMov}{1}(k).smNetVelocity(iCol,:);
+                normVel1 = norm(vel1);
+                for iAng = 1 : length(mtchindx)
+                    vel2 = combinePropPerTimeInt{iMov}{1}(k).speckleVelocity{iCol,1}(iAng,:);
+                    normVel2 = norm(vel2);
+                    if normVel2 > 0 && normVel1 > 0
+                        combinePropPerTimeInt{iMov}{1}(k).([nn 'smComvmtAngle']){iCol,1}(iAng,1) = ...
+                            acosd(dot(vel1,vel2) / (normVel1*normVel2));
+                    else
+                        combinePropPerTimeInt{iMov}{1}(k).([nn 'smComvmtAngle']){iCol,1}(iAng,1) = NaN;
+                    end
+                end
+                
+                vel2 = combinePropPerTimeInt{iMov}{2}(k).speckleVelocity(iCol,:);
+                normVel2 = norm(vel2);
+                if normVel2 > 0 && normVel1 > 0
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'smComvmtAngle'])(iCol,1) = ...
+                        acosd(dot(vel1,vel2) / (normVel1*normVel2));
+                else
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'smComvmtAngle'])(iCol,1) = NaN;
+                end
+                
+            end
+            
+            %Intensity
+            
+            %KJ 20210712: Fixed bug in calculating ILMaxCorrected and
+            %IBkgCorrected. Previous implementation (in 20210602) did not
+            %handle properly the case when multiple speckles are matched to
+            %an SM in a single frame
+
+            intPerFrame = NaN(size(matSpkAtSmFrIndx));
+            intPerFrame(indxGood) = actinPropPerTimeInt{iMov}(k).ILmax(matSpkAtSmFrIndx(indxGood)); %indxGood is from Line 276 above
+            intPerFrameMean = nanmean(intPerFrame,1);
+            
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'ILmax']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).ILmax(mtchindx);            
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'ILmax'])(iCol,1) = ...
+                nanmean(intPerFrameMean);
+            switch smactinFlag.combFlag(iMov)                
+                case 7
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'ILmaxCorrected'])(iCol,1) = ...
+                        combinePropPerTimeInt{iMov}{2}(k).([nn 'ILmax'])(iCol,1);
+                case 10
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'ILmaxCorrected'])(iCol,1) = ...
+                        nansum(intPerFrameMean)/numSmFr;
+            end
+            
+            intPerFrame = NaN(size(matSpkAtSmFrIndx));
+            intPerFrame(indxGood) = actinPropPerTimeInt{iMov}(k).IBkg(matSpkAtSmFrIndx(indxGood));
+            intPerFrameMean = nanmean(intPerFrame,1);
+
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'IBkg']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).IBkg(mtchindx);
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'IBkg'])(iCol,1) = ...
+                nanmean(intPerFrameMean);
+            switch smactinFlag.combFlag(iMov)
+                case 7
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'IBkgCorrected'])(iCol,1) = ...
+                        combinePropPerTimeInt{iMov}{2}(k).([nn 'IBkg'])(iCol,1);
+                case 10
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'IBkgCorrected'])(iCol,1) = ...
+                        nansum(intPerFrameMean)/numSmFr;
+            end
+            
+            %Density
+            
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleDensity']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).speckleDensity(mtchindx);
+            
+            switch smactinFlag.combFlag(iMov)
+                
+                case 7  
+                    
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleDensity'])(iCol,1) = ...
+                        size(mtchindx,1)/(pi*(combinePropPerTimeInt{iMov}{2}(k).rad_match)^2);
+                    
+                case 10
+                    
+                    spklCountEachFr = nansum(~isnan(combinePropPerTimeInt{iMov}{1}(k).spklMtchPerSmFr{iCol,1}),1);
+                    meanSpklCount = mean(spklCountEachFr);
+                    searchArea = pi*(combinePropPerTimeInt{iMov}{2}(k).rad_match)^2;
+                    
+                    combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleDensity'])(iCol,1) = ...
+                        meanSpklCount/searchArea;
+                    
+            end
+            
+            %Lifetime
+            
+            combinePropPerTimeInt{iMov}{1}(k).([nn 'speckleLifetime']){iCol,1} = ...
+                actinPropPerTimeInt{iMov}(k).speckleLifetime(mtchindx);
+            combinePropPerTimeInt{iMov}{2}(k).([nn 'speckleLifetime'])(iCol,1) = ...
+                nanmean(actinPropPerTimeInt{iMov}(k).speckleLifetime(mtchIndxBySmFr));
+                        
+        end %(for iCol = 1 : size(distMat,2))
+        
+    end %(for k = combineConditions.firstFsmFrame(iMov): smIntervals(iMov))
+    
+end %(for iMov = 1 : numMovs)
+
+end


### PR DESCRIPTION
The following functions were updated: smPropPerTimeInterval, smactinPropPerTimeInt, retainSmPropInMask, smactinMat, retainTassmInliers, smactinClean, runSmactinAggMovExplain, multiCompareIndCellsMVRG.
The following functions contain some comment refinement but no code change: actinPropPerTimeInterval, cleanActinPropPerTimeInt, scan4smSpeckleThreshold, plotBiphasicLines.